### PR TITLE
Update css files and restructure release notes

### DIFF
--- a/source/_static/custom.css
+++ b/source/_static/custom.css
@@ -1,3 +1,60 @@
+@import "https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css";
+
+.admonition-title {
+  font-size: 1.5rem !important;
+  margin: 2rem 0 1rem !important;
+  font-family: 'Open sans', sans-serif !important;
+  font-weight: 700 !important;
+  color: #5AC8FA; }
+  .admonition-title::before {
+    content: "\f06e"; }
+
+.admonition .admonition-title::before {
+  display: inline-block;
+  font: normal normal normal 14px/1 FontAwesome;
+  font-size: inherit;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  margin-right: 10px; }
+.admonition.danger .admonition-title {
+  color: #FF3B30; }
+  .admonition.danger .admonition-title::before {
+    content: "\f071"; }
+.admonition.warning .admonition-title {
+  color: #FF9500; }
+  .admonition.warning .admonition-title::before {
+    content: "\f06a"; }
+
+#toc > ul {
+  margin: 0;
+  padding: 0; }
+  #toc > ul li {
+    margin-bottom: .7rem; }
+    #toc > ul li.toctree-l2 > a {
+      border-left: 1px solid #eee; }
+    #toc > ul li.toctree-l3 > a {
+      border-left: 1px solid #ddd; }
+    #toc > ul li.toctree-l4 > a {
+      border-left: 1px solid #ccc; }
+    #toc > ul li.toctree-l5 a {
+      border-left: 1px solid #bbb; }
+    #toc > ul li.toctree-l2 > a:hover, #toc > ul li.toctree-l3 > a:hover, #toc > ul li.toctree-l4 > a:hover, #toc > ul li.toctree-l5 a:hover {
+      border-left-color: #af0e14; }
+  #toc > ul > li {
+    margin-bottom: 1rem; }
+  #toc > ul a {
+    display: block;
+    padding: 0 1rem; }
+    #toc > ul a:hover {
+      color: #af0e14; }
+    #toc > ul a + ul {
+      margin-top: .7rem; }
+#toc li.current > a {
+  color: #555; }
+
+/*# sourceMappingURL=custom.css.map */
+
 .wy-side-nav-search {
     background-color: #ED1C24;
 }

--- a/source/_static/custom.scss
+++ b/source/_static/custom.scss
@@ -1,0 +1,113 @@
+
+@import "https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css";
+
+$crimson: #ed1c24;
+$dark: #404041;
+$gold: #c2b59b;
+$blue: #08c;
+$custom-red: darken($crimson, 15%); // #D9411E;
+$custom-gray: #fcfcfc;
+$sidebar-sm: 250px;
+$sidebar-lg: 320px;
+
+$color-red: #FF3B30;
+$color-orange: #FF9500;
+$color-teal: #5AC8FA;
+
+.admonition-title {
+  font-size: 1.5rem !important;
+  margin: 2rem 0 1rem !important;
+  font-family: 'Open sans', sans-serif !important;
+  font-weight: 700 !important;
+  color: $color-teal;
+  &::before {
+    content: "\f06e";
+  }
+}
+
+.admonition {
+  .admonition-title {
+    &::before {
+      display: inline-block;
+      font: normal normal normal 14px/1 FontAwesome;
+      font-size: inherit;
+      text-rendering: auto;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      margin-right: 10px;
+    }
+  }
+  &.danger {
+    .admonition-title {
+      color: $color-red;
+      &::before {
+        content: "\f071";
+      }
+    }
+  }
+  &.warning {
+    .admonition-title {
+      color: $color-orange;
+      &::before {
+        content: "\f06a";
+      }
+    }
+  }
+  &.note {
+    // currently the default...
+  }
+}
+
+#toc {
+  > ul {
+    margin: 0;
+    padding: 0;
+    li {
+      margin-bottom: .7rem;
+      &.toctree-l2 {
+        > a {
+          border-left: 1px solid #eee;
+        }
+      }
+      &.toctree-l3 {
+        > a {
+          border-left: 1px solid #ddd;
+        }
+      }
+      &.toctree-l4 {
+        > a {
+          border-left: 1px solid #ccc;
+        }
+      }
+      &.toctree-l5 {
+        a {
+          border-left: 1px solid #bbb;
+        }
+      }
+      &.toctree-l2 > a,
+      &.toctree-l3 > a,
+      &.toctree-l4 > a,
+      &.toctree-l5 a {
+        &:hover {
+          border-left-color: $custom-red;
+        }
+      }
+    }
+    > li {
+      margin-bottom: 1rem;
+    }
+    a {
+      display: block;
+      padding: 0 1rem;
+      &:hover {
+        color: $custom-red;
+      }
+      + ul {
+        margin-top: .7rem;
+      }
+    }
+  }
+  li.current > a {
+    color: #555;
+  }
+}

--- a/source/conf.py
+++ b/source/conf.py
@@ -135,7 +135,7 @@ html_theme_options = {
 }
 
 # Adding additional css files...
-# html_context = { "extra_css_files": ["_static/custom.css"] }
+html_context = { "extra_css_files": ["_static/custom.css"] }
 
 
 html_show_sphinx = False

--- a/source/release-notes/index.rst
+++ b/source/release-notes/index.rst
@@ -1,8 +1,10 @@
 .. _release-notes:
 
-=============
-Release Notes
-=============
+=============================
+Crafter CMS 2.5 Release Notes
+=============================
+
+For other release notes, please visit your release's release notes page here: http://docs.craftercms.org
 
 .. include:: /release-notes/2-5-15.rst
 


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
Restructure release notes #1845 
Update css files to make updates for admonitions (make admonitions pop) and toc (make toc entries distinguishable) like in 3.0