### PR TITLE
Syntax fix + style fix for Solr query example

### DIFF
--- a/source/developers/cook-books/content-queries/basic-query-mechanics.rst
+++ b/source/developers/cook-books/content-queries/basic-query-mechanics.rst
@@ -36,7 +36,7 @@ You can find the interface for this service :javadoc_base_url:`HERE <search/org/
 
 .. code-block:: groovy
 
-    def queryStatement = "author:\"Russ Danner\""
+    def queryStatement = "author:\"John Doe\""
 
     def query = searchService.createQuery()
     query.setQuery(queryStatement)

--- a/source/developers/cook-books/content-queries/basic-query-mechanics.rst
+++ b/source/developers/cook-books/content-queries/basic-query-mechanics.rst
@@ -36,10 +36,11 @@ You can find the interface for this service :javadoc_base_url:`HERE <search/org/
 
 .. code-block:: groovy
 
-    def queryStatement = 'content-type:"/component/article" AND author:"Russ Danner"'
+    def queryStatement = "author:\"Russ Danner\""
 
     def query = searchService.createQuery()
-    query = query.setQuery(queryStatement)
+    query.setQuery(queryStatement)
+    query.addFilterQuery("content-type:/component/article")
 
     def executedQuery = searchService.search(query)
     def itemsFound = executedQuery.response.numFound


### PR DESCRIPTION
This PR fixes a syntax issue with the groovy solr query. The single/double quote fails to parse on crafter 3.0.20. Secondly, content-type queries are more suitable for filter queries in solr rather than queries located in the main query string.