### PR TITLE
Add note that passphrase is not supported for ssh key for 3.0

### DIFF
--- a/source/includes/setup-ssh-keys.rst
+++ b/source/includes/setup-ssh-keys.rst
@@ -6,9 +6,8 @@ To generate your Secure Shell (SSH) keys for authentication, run the following c
     ✗ ssh-keygen -b 4096 -t rsa
     Generating public/private rsa key pair.
     Enter file in which to save the key (/Users/myuser/.ssh/id_rsa):
-    .
-    .
-    .
+    Enter passphrase (empty for no passphrase):
+    Enter same passphrase again:
     Your identification has been saved in /Users/myuser/.ssh/id_rsa.
     Your public key has been saved in /Users/myuser/.ssh/id_rsa.pub.
     .

--- a/source/system-administrators/activities/debugging-ssh-issues.rst
+++ b/source/system-administrators/activities/debugging-ssh-issues.rst
@@ -1,0 +1,74 @@
+.. _debugging_ssh_issues:
+
+========================
+Debugging SSH Key Issues
+========================
+
+In this section, we present a few errors that a user may encounter when using ssh keys with Crafter CMS and how to fix the errors.
+
+----------------
+SSH Unknown Host
+----------------
+
+When creating a site with a link to a remote repository using SSH keys or when configuring a Deployer target to connect to a remote host through SSH, you might encounter the following error:
+
+.. code-block:: java
+
+	com.jcraft.jsch.JSchException: UnknownHostKey: SERVER_NAME. RSA key fingerprint is 50:db:75:ba:11:2f:43:c9:ab:14:40:6d:7f:a1:ee:e3
+
+|
+
+This normally means that the SSH host key from the remote server is stored in ECDSA format instead of RSA, under ``known_hosts``.
+Crafter requires the host key to be RSA. To fix this do the following:
+
+#. Delete the ``~/.ssh/known_hosts`` file for the user that's running Crafter.
+#. Connect to the remote server with the following command to add the RSA key: ``ssh -o HostKeyAlgorithms=ssh-rsa SERVER_NAME``.
+
+------------------------------------------
+Remote Repository Not Found: USERAUTH fail
+------------------------------------------
+
+Here's another error you may encounter in the logs when creating a site with a link to a remote repository using SSH keys:
+
+.. code-block:: java
+
+    com.jcraft.jsch.JSchException: USERAUTH fail
+
+|
+
+This could mean that a passphrase was setup for the SSH keys.  Crafter currently doesn't support using a passphrase with SSH keys.  To fix the error, remove the passphrase from the SSH key.
+
+There are a couple of ways to remove the passphrase from the SSH key:
+
+#. Delete your existing key and generate a new key with NO PASSPHRASE.
+#. Or, another way is to run the following:
+
+   .. code-block:: sh
+
+       $ ssh-keygen -p
+
+   |
+
+   It will then prompt you to enter the keyfile location, the old passphrase, and the new passphrase (leave this blank to have no passphrase).
+
+-------------------
+Invalid Private Key
+-------------------
+
+You may encounter in the logs when creating a site with a link to a remote repository using SSH keys the following error:
+
+.. code-block:: sh
+
+    com.jcraft.jsch.JSchException: invalid privatekey: [B@5f13fa57
+
+|
+
+This could be caused by keys generated using an algorithm other than RSA.  Crafter requires the key to be RSA.  Make sure when you generate the key to specify the type as ``rsa``:
+
+.. code-block:: sh
+
+    ssh-keygen -b 4096 -t rsa
+
+|
+
+Also, check that the file starts with the following header: ``-----BEGIN RSA PRIVATE KEY-----`` to verify that the key is using RSA.

--- a/source/system-administrators/activities/troubleshooting.rst
+++ b/source/system-administrators/activities/troubleshooting.rst
@@ -12,3 +12,4 @@ This section details common problems you might encounter with Crafter CMS and ho
    debugging-search.rst
    ../studio/debugging-publishing-issues.rst
    ../deployer/debugging-deployer-issues.rst
+   debugging-ssh-issues.rst

--- a/source/system-administrators/index.rst
+++ b/source/system-administrators/index.rst
@@ -109,6 +109,7 @@ Crafter Deployer
    :titlesonly:
 
    deployer/admin-guide.rst
+   deployer/debugging-deployer-issues.rst
 
 
 ==============

--- a/source/system-administrators/studio/create-site-with-link-to-remote-repo.rst
+++ b/source/system-administrators/studio/create-site-with-link-to-remote-repo.rst
@@ -45,7 +45,7 @@ Let's take a look at the fields displayed when **Link to upstream remote Git rep
    The field **Blueprint** is available when the option **Create site based on a blueprint then push to remote bare Git repository** is selected.  Choose one of the default or choose your own.  The available default blueprints are as follows: Empty, Headless_blog, Headless_store and Website_editorial
 
 .. note::
-        When using ssh keys for authentication, the keys need to be generated using **RSA** as the algorithm
+        When using ssh keys for authentication, the keys need to be generated using **RSA** as the algorithm and with **no passphrase**.
 
         .. include:: /includes/setup-ssh-keys.rst
 


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
Add note that passphrase is not supported for ssh key for 3.0