### PR TITLE
set the default port for ajp to 9009 for delivery

### DIFF
--- a/source/system-administrators/activities/delivery/configure-apache-vhost.rst
+++ b/source/system-administrators/activities/delivery/configure-apache-vhost.rst
@@ -47,8 +47,8 @@ Here's the sample configuration for setting up a vhost for production:
         ProxyPass /static-assets !
 
         # Send requests to Engine's Tomcat
-        ProxyPass / ajp://localhost:8009/
-        ProxyPassReverse / ajp://localhost:8009/
+        ProxyPass / ajp://localhost:9009/
+        ProxyPassReverse / ajp://localhost:9009/
 
         # This is where errors related to this virtual host are stored
         ErrorLog ${APACHE_LOG_DIR}/mysite-error.log


### PR DESCRIPTION
This is to follow the same ports as the file crafter-setenv.sh for the delivery
