### PR TITLE
Revert change of blueprint name to empty

### DIFF
--- a/source/developers/projects/studio/api/site/create-site.rst
+++ b/source/developers/projects/studio/api/site/create-site.rst
@@ -91,7 +91,7 @@ Example
   {
     "site_id" : "my-site",
     "description" : "My very first site!",
-    "blueprint" : "org.craftercms.blueprint.empty"
+    "blueprint" : "empty"
   }
 
 .. code-block:: json


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
In 3.0 the blueprint parameter is `empty`