### PR TITLE
Fix ElasticsearchWrapper javadoc link

### DIFF
--- a/source/developers/cook-books/content-queries/basic-query-mechanics.rst
+++ b/source/developers/cook-books/content-queries/basic-query-mechanics.rst
@@ -58,7 +58,7 @@ Make an Elasticsearch Query
 To perform content queries in Elasticsearch you need to use the client provided by Crafter Engine, the bean name is
 ``elasticsearch`` and it can be used from any Groovy script.
 
-You can find the interface for this service :javadoc_base_url:`here <search/org/craftercms/search/elasticssearch/ElasticSearchWrapper.html>`
+You can find the interface for this service :javadoc_base_url:`here <search/org/craftercms/search/elasticsearch/ElasticsearchWrapper.html>`
 
 This client provides two ways for running queries:
 

--- a/source/includes/global-groovy-variables.rst
+++ b/source/includes/global-groovy-variables.rst
@@ -73,7 +73,7 @@
 .. _PropertySources: https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/core/env/PropertySourcesPropertyResolver.html
 .. |UrlTransformationService| replace:: :javadoc_base_url:`UrlTransformationService <engine/org/craftercms/engine/service/UrlTransformationService.html>`
 .. |SearchService| replace:: :javadoc_base_url:`SearchService <search/org/craftercms/search/service/SearchService.html>`
-.. |ElasticsearchWrapper| replace:: :javadoc_base_url:`ElasticsearchWrapper <org/craftercms/search/elasticsearch/ElasticsearchWrapper.html>`.
+.. |ElasticsearchWrapper| replace:: :javadoc_base_url:`ElasticsearchWrapper <search/org/craftercms/search/elasticsearch/ElasticsearchWrapper.html>`
 .. |ApplicationContextAccessor| replace:: :javadoc_base_url:`ApplicationContextAccessor <engine/org/craftercms/engine/util/spring/ApplicationContextAccessor.html>`
 .. |BreadcrumbBuilder| replace:: :javadoc_base_url:`BreadcrumbBuilder <engine/org/craftercms/engine/navigation/NavBreadcrumbBuilder.html>`
 .. |NavTreeBuilder| replace:: :javadoc_base_url:`NavTreeBuilder <engine/org/craftercms/engine/navigation/NavTreeBuilder.html>`


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
Fix link redirects to the javadoc http://javadoc.craftercms.org/3.1.0/search/org/craftercms/search/elasticsearch/ElasticsearchWrapper.html 