### PR TITLE
Add note for macOS 10.14 or OpenSSH 7.8 users to use -m PEM when creating ssh keys #3719

### DIFF
--- a/source/includes/setup-ssh-keys.rst
+++ b/source/includes/setup-ssh-keys.rst
@@ -1,3 +1,6 @@
+When using ssh keys for authentication, the keys need to be generated using ``RSA`` as the algorithm  and with ``no passphrase``.
+
+Crafter requires the key to be ``RSA`` and does not support keys generated using an algorithm other than ``RSA``.  The Jsch library that Jgit uses only supports ``RSA`` and does not support other keys such as OpenSSH. Crafter also currently doesn't support using a passphrase with SSH keys.
 
 To generate your Secure Shell (SSH) keys for authentication, run the following command ``ssh-keygen -b 4096 -t rsa``.  Your output should look something like this:
 
@@ -15,5 +18,16 @@ To generate your Secure Shell (SSH) keys for authentication, run the following c
 
 |
 
+    .. note::
+
+        For users on macOS 10.14 and above (macOS Mojave and onwards) or users using OpenSSH 7.8 and above, ``ssh-keygen`` writes OpenSSH format private keys by default (RFC7416 format) instead of using OpenSSL's PEM format.
+
+        To generate keys using PEM format, add option ``-m PEM`` into your ssh-keygen command. For example, you can run ``ssh-keygen -m PEM -t rsa -b 4096 -C "your_email@example.com"`` to force ssh-keygen to export as PEM format.
+
+|
+
+Check that the file starts with the following header: ``-----BEGIN RSA PRIVATE KEY-----`` to verify that the key is using ``RSA``.
+
 After generating your private and public keys, you will need to add your new public key to where your remote git repository is located.  If you are using GitHub, you will need to add your public key (e.g., ``id_rsa.pub``) into your GitHub account.  If your remote Git repository is hosted on a server, you will need to copy your public key (e.g., ``id_rsa.pub``) to the host server.
+
 

--- a/source/system-administrators/activities/debugging-ssh-issues.rst
+++ b/source/system-administrators/activities/debugging-ssh-issues.rst
@@ -65,7 +65,7 @@ You may encounter in the logs when creating a site with a link to a remote repos
 
 |
 
-This could be caused by keys generated using an algorithm other than RSA.  Crafter requires the key to be RSA.  Make sure when you generate the key to specify the type as ``rsa``:
+This could be caused by keys generated using an algorithm other than ``RSA``.  Crafter requires the key to be ``RSA`` and does not support keys generated using an algorithm (such as OPENSSH) other than **RSA**.  Make sure when you generate the key to specify the type as ``rsa``:
 
 .. code-block:: sh
 
@@ -73,4 +73,14 @@ This could be caused by keys generated using an algorithm other than RSA.  Craft
 
 |
 
-Also, check that the file starts with the following header: ``-----BEGIN RSA PRIVATE KEY-----`` to verify that the key is using RSA.
+Also, check that the file starts with the following header: ``-----BEGIN RSA PRIVATE KEY-----`` to verify that the key is using ``RSA``.
+
+    .. note::
+        For users on macOS 10.14 and above (macOS Mojave and onwards) or users using OpenSSH 7.8 and above, ``ssh-keygen`` writes OpenSSH format private keys by default (RFC7416 format) instead of using OpenSSL's PEM format.
+
+        To generate keys using PEM format, add option ``-m PEM`` into your ssh-keygen command. For example, you can run the command below  to force ssh-keygen to export as PEM format:
+
+        .. code-block:: sh
+
+           ssh-keygen -m PEM -t rsa -b 4096 -C "your_email@example.com"
+

--- a/source/system-administrators/activities/delivery/setup-site-for-delivery.rst
+++ b/source/system-administrators/activities/delivery/setup-site-for-delivery.rst
@@ -73,10 +73,8 @@ Example #1: ``ssh://server1.example.com/path/to/repo``
 
 Example #2: ``ssh://jdoe@server2.example.com:63022/path/to/repo``
 
-.. note::
-    When using ssh, your keys need to be generated using **RSA** as the algorithm
-
-    .. include:: /includes/setup-ssh-keys.rst
+   .. note::
+      .. include:: /includes/setup-ssh-keys.rst
 
 If you are just working on another directory on disk for your delivery, you can just use the filesystem.  When your repository is local, make sure to use the absolute path.
 Here is an example site's published repo Git url when using a local repository:

--- a/source/system-administrators/activities/kubernetes/simple-kubernetes-deployment.rst
+++ b/source/system-administrators/activities/kubernetes/simple-kubernetes-deployment.rst
@@ -32,6 +32,30 @@ an SSH public/private key pair for authentication and provide the key pair as a 
 #. Run ``ssh-keygen -b 4096 -t rsa -C "your_email@example.com"`` to generate the key pair. When being asked for the 
    filename of the key, just enter ``id_rsa`` (so that the keys are saved in the current folder). Do not provide a 
    passphrase.
+
+      .. note::
+         Crafter requires the key to be ``RSA`` and does not support keys generated using an algorithm other than ``RSA``.  The Jsch library that Jgit uses only supports ``RSA`` and does not support other keys such as OpenSSH.  Make sure when you generate the key to specify the type as ``rsa``:
+
+         .. code-block:: sh
+
+            ssh-keygen -b 4096 -t rsa -C "your_email@example.com"
+
+         |
+
+         For users on macOS 10.14 and above (macOS Mojave and onwards) or users using OpenSSH 7.8 and above, ``ssh-keygen`` writes OpenSSH format private keys by default (RFC7416 format) instead of using OpenSSL's PEM format.
+
+         To generate keys using PEM format, add option ``-m PEM`` into your ssh-keygen command. For example, you can run the command below  to force ssh-keygen to export as PEM format:
+
+         .. code-block:: sh
+
+            ssh-keygen -m PEM -t rsa -b 4096 -C "your_email@example.com"
+
+         |
+
+         Also, check that the file starts with the following header: ``-----BEGIN RSA PRIVATE KEY-----`` to verify that the key is using ``RSA``.
+         Crafter also currently doesn't support using a passphrase with SSH keys.  Remember to **NOT** use a passphrase when creating your keys.
+
+
 #. Create a copy of the public key and rename it to ``authorized_keys``: ``cp id_rsa.pub authorized_keys``.
 #. In the same folder, create a ``config`` file with the following, to disable ``StrictHostKeyChecking`` for automatic 
    connection to the Authoring SSH server:

--- a/source/system-administrators/studio/create-site-with-link-to-remote-repo.rst
+++ b/source/system-administrators/studio/create-site-with-link-to-remote-repo.rst
@@ -30,20 +30,18 @@ Let's take a look at the fields where the remote repository details needs to be 
 
    Crafter CMS supports the following authentication types to use to access remote repository:
 
-        - **None** - no credentials needed to access remote repository
-        - **Basic** - for this method, you will be asked for a **Remote Git Repository Username** and a **Remote Git Repository Password**.  Supply your username and password
-        - **Remote Git Repository Token** - for this method, you will be asked for a **Remote Git Repository Username** (if required) and a **Remote Git Repository Token**.  This method is usually used when two-factor authentication is configured on the remote repository to be accessed. Supply your username if required and token.
-        - **Remote Git Repository Private Key** - for this method, you will be asked for a **Remote Git Repository Private Key**.  This method is a key-based authentication.  Supply your private key.
+   - **None** - no credentials needed to access remote repository
+   - **Basic** - for this method, you will be asked for a **Remote Git Repository Username** and a **Remote Git Repository Password**.  Supply your username and password
+   - **Remote Git Repository Token** - for this method, you will be asked for a **Remote Git Repository Username** (if required) and a **Remote Git Repository Token**.  This method is usually used when two-factor authentication is configured on the remote repository to be accessed. Supply your username if required and token.
+   - **Remote Git Repository Private Key** - for this method, you will be asked for a **Remote Git Repository Private Key**.  This method is a key-based authentication.  Supply your private key.
 
-.. note::
-        When using ssh keys for authentication, the keys need to be generated using **RSA** as the algorithm  and with **no passphrase**.
+      .. note::
+         .. include:: /includes/setup-ssh-keys.rst
 
-        .. include:: /includes/setup-ssh-keys.rst
+         After copying your public keys to where your remote git repository is located, there are a couple of ways to setup the way Crafter Studio accesses the remote repository:
 
-        After copying your public keys to where your remote git repository is located, there are a couple of ways to setup the way Crafter Studio accesses the remote repository:
-
-        #. Set the authentication type to **Remote Git Repository Private Key** in the ``Create Site`` screen, then specify your private key in the **Remote Git Repository Private Key** field.
-        #.  Set the authentication type to **None** in the ``Create Site`` screen, if you put the key in the default RSA key path in the Crafter Studio server (~/.ssh/id_rsa).  Remember the key needs to use the default filename (``id_rsa`` and ``id_rsa.pub``) when using this method of setting up access to the remote repository. Also, remember that **Studio must be restarted** for the JVM to pick up the default key.
+         #. Set the authentication type to **Remote Git Repository Private Key** in the ``Create Site`` screen, then specify your private key in the **Remote Git Repository Private Key** field.
+         #.  Set the authentication type to **None** in the ``Create Site`` screen, if you put the key in the default RSA key path in the Crafter Studio server (~/.ssh/id_rsa).  Remember the key needs to use the default filename (``id_rsa`` and ``id_rsa.pub``) when using this method of setting up access to the remote repository. Also, remember that **Studio must be restarted** for the JVM to pick up the default key.
 
 ------------------------------------------------------------------------
 Create site based on a blueprint then push to remote bare Git repository


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
Add note for macOS 10.14 or OpenSSH 7.8 and up users to use -m PEM when creating ssh keys #3719