### PR TITLE
Update code-block guess lexers for updated sphinx-doc version

### DIFF
--- a/source/developers/content-modeling.rst
+++ b/source/developers/content-modeling.rst
@@ -495,7 +495,7 @@ Check the **Show in Quick Create** property to make the content type available f
 
 In the **Destination Path Pattern**, fill in the path pattern where the content created from quick create will be stored.  For our example, notice that the articles are arranged in the following folder structure:
 
-.. code-block:: guess
+.. code-block:: text
 
    /articles
      /{year}
@@ -717,7 +717,9 @@ View templates control how the model is rendered as HTML. Crafter uses `FreeMark
 
 An example view template
 
-.. code-block:: guess
+
+.. code-block:: html
+   :force:
    :linenos:
 
    <#import "/templates/system/common/cstudio-support.ftl" as studio />

--- a/source/developers/content-type-component.rst
+++ b/source/developers/content-type-component.rst
@@ -145,7 +145,7 @@ A dialog will then open where you can start entering your script.  Let's take a 
 
 |
 
-.. code-block:: guess
+.. code-block:: groovy
     :linenos:
 
     import org.craftercms.sites.editorial.SearchHelper

--- a/source/developers/content-type-page.rst
+++ b/source/developers/content-type-page.rst
@@ -196,7 +196,8 @@ We will now start filling in the template of how we want the content captured in
 
 |
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
     :caption: *Render header*
 
     <!-- Header -->
@@ -204,7 +205,8 @@ We will now start filling in the template of how we want the content captured in
 
 |
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
     :caption: *Render content section*
     :linenos:
 
@@ -262,7 +264,7 @@ We can now start adding the script to get a list of articles depending on the ac
 
 |
 
-.. code-block:: guess
+.. code-block:: groovy
     :linenos:
 
     import org.craftercms.sites.editorial.SearchHelper
@@ -288,7 +290,8 @@ Now that we have our controller, we just need to add code to the freemarker temp
 
 |
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
     :linenos:
 
     <section>

--- a/source/developers/cook-books/aws/upload-transcode-video.rst
+++ b/source/developers/cook-books/aws/upload-transcode-video.rst
@@ -142,7 +142,8 @@ For our example, we'll add the Video Transcoding from S3 datasource and a Video 
     In the ``Templates`` > ``web`` > ``pages`` > ``article.ftl``, add the following lines after the
     ``<section><header class="main" <@studio.iceAttr iceGroup="subject"/>>...</#section>`` lines:
 
-    .. code-block:: guess
+    .. code-block:: html
+       :force:
        :linenos:
 
        <!-- AWSVideoTranscoding -->

--- a/source/developers/cook-books/aws/use-s3-to-store-assets.rst
+++ b/source/developers/cook-books/aws/use-s3-to-store-assets.rst
@@ -110,7 +110,8 @@ data source, to the ``Page - Article`` content type. To do this:
     the ``Templates`` > ``web`` > ``pages`` > ``article.ftl``, add the following lines after the
     ``<#list contentModel.sections.item as item>...</#list>`` lines:
 
-    .. code-block:: guess
+    .. code-block:: html
+       :force:
        :linenos:
 
        <#if contentModel.attachments??>

--- a/source/developers/cook-books/blueprint/index.rst
+++ b/source/developers/cook-books/blueprint/index.rst
@@ -287,7 +287,7 @@ Let's take a look at an example of adding parameters to the **Website Editorial*
 
 #. Commit your changes
 
-   .. code-block:: guess
+   .. code-block:: text
 
       ➜  craftercms git:(develop) cd crafter-authoring/data/repos/global/blueprints/1000_website_editorial
       ➜  1000_website_editorial git:(master) ✗ vi craftercms-plugin.yaml

--- a/source/developers/cook-books/box/use-box-to-store-assets.rst
+++ b/source/developers/cook-books/box/use-box-to-store-assets.rst
@@ -115,7 +115,8 @@ Step 4: Add Freemarker code to render the URLs
 
 We need to add the Freemarker code that will render the URLs. In the ``Templates`` > ``web`` > ``pages`` > ``article.ftl``, add the following lines after the ``<#list contentModel.sections.item as item>...</#list>`` lines:
 
-.. code-block:: guess
+.. code-block:: html
+  :force:
 
   <#if contentModel.attachments??>
      <h2>Attachments</h2>

--- a/source/developers/cook-books/graphql/custom-graphql-schema.rst
+++ b/source/developers/cook-books/graphql/custom-graphql-schema.rst
@@ -209,7 +209,7 @@ The following example shows how to customize the schema to integrate a service w
     
     #.  The first step is to define a generic entry type that includes all common fields present in movies and series:
     
-        .. code-block:: guess
+        .. code-block:: text
           :caption: GraphQL interface for all entries
           :linenos:
         
@@ -226,7 +226,7 @@ The following example shows how to customize the schema to integrate a service w
     #.  Next step is to define the concrete types for movies and series, those will have all fields from the parent
         type but include new ones:
         
-        .. code-block:: guess
+        .. code-block:: text
           :caption: GraphQL type for movies
           :linenos:
         
@@ -239,7 +239,7 @@ The following example shows how to customize the schema to integrate a service w
             Production: String!
           }
         
-        .. code-block:: guess
+        .. code-block:: text
           :caption: GraphQL type for series
           :linenos:
         
@@ -254,7 +254,7 @@ The following example shows how to customize the schema to integrate a service w
         
     #.  Finally the service call will be exposed using a wrapper type:
         
-        .. code-block:: guess
+        .. code-block:: text
           :caption: GraphQL type for the service
           :linenos:
         

--- a/source/developers/cook-books/graphql/working-with-graphql.rst
+++ b/source/developers/cook-books/graphql/working-with-graphql.rst
@@ -93,7 +93,7 @@ of ``items``.
 
 One of simplest GraphQL queries you can run in Crafter CMS sites is to find all items of a given content-type.
 
-.. code-block:: guess
+.. code-block:: text
   :linenos:
   :caption: Query for all ``/page/article`` items
 
@@ -114,7 +114,7 @@ One of simplest GraphQL queries you can run in Crafter CMS sites is to find all 
 
 You can also run queries to find all pages, components or content items (both pages and components).
 
-.. code-block:: guess
+.. code-block:: text
   :linenos:
   :caption: Query for all pages
 
@@ -136,7 +136,7 @@ You can also run queries to find all pages, components or content items (both pa
     }
   }
 
-.. code-block:: guess
+.. code-block:: text
   :linenos:
   :caption: Query for all components
 
@@ -155,7 +155,7 @@ You can also run queries to find all pages, components or content items (both pa
     }
   }
 
-.. code-block:: guess
+.. code-block:: text
   :linenos:
   :caption: Query for all content items
 
@@ -178,7 +178,7 @@ As you can expect if there are too many items for a given query the result will 
 implement pagination using the ``offset`` and ``limit`` parameters. For example the following query
 will return only the first five items found.
 
-.. code-block:: guess
+.. code-block:: text
   :linenos:
   :caption: Paginated query for content-type ``/page/article``
 
@@ -201,7 +201,7 @@ By default all items will be sorted using the ``lastModifiedDate_dt`` in descend
 the ``sortBy`` and ``sortOrder`` parameters. For example you can use the ``date_dt`` field that is specific for the 
 ``/page/article`` content-type to sort.
 
-.. code-block:: guess
+.. code-block:: text
   :linenos:
   :caption: Paginated and sorted query for content-type ``/page/article``
 
@@ -224,7 +224,7 @@ Besides finding all items for a specific content-type, it is also possible to fi
 fields in the query. Fields will have different filters depending on their type, for example you can find items for
 a specific author.
 
-.. code-block:: guess
+.. code-block:: text
   :linenos:
   :caption: Paginated, sorted and filtered query for content-type ``/page/article``
 
@@ -246,7 +246,7 @@ a specific author.
 
 Additionally you can create complex filters using expressions like ``and``, ``or`` and ``not`` for any field:
 
-.. code-block:: guess
+.. code-block:: text
   :linenos:
   :caption: Filtered query with complex conditions
 
@@ -293,7 +293,7 @@ Additionally you can create complex filters using expressions like ``and``, ``or
 You can also include fields from child components in your model, this applies to fields like ``node-selector``,
 ``checkbox-group`` and ``repeat`` groups. Filters can also be added to fields from child components.
 
-.. code-block:: guess
+.. code-block:: text
   :linenos:
   :caption: Paginated, sorted and filtered query for content-type ``/page/article`` using child components
 
@@ -323,7 +323,7 @@ You can also include fields from child components in your model, this applies to
 GraphQL ``aliases`` are supported on root level query fields (``contentItems``, ``pages``, ``components`` and content 
 type fields).
 
-.. code-block:: guess
+.. code-block:: text
    :linenos:
    :caption: Query for 2016 and 2017 articles using aliases
 
@@ -346,7 +346,7 @@ type fields).
 GraphQL ``fragments`` are fully supported and can be used inline or as spreads. Using fragments you can simplify
 queries by extracting repeated fields or request specific fields for different content-types in as single query:
 
-.. code-block:: guess
+.. code-block:: text
   :linenos:
   :caption: Using fragment spreads to simplify a query
 
@@ -379,7 +379,7 @@ queries by extracting repeated fields or request specific fields for different c
     }
   }
 
-.. code-block:: guess
+.. code-block:: text
   :linenos:
   :caption: Using inline fragments to request specific fields in a single query
 

--- a/source/developers/cook-books/how-tos/components-in-rte.rst
+++ b/source/developers/cook-books/how-tos/components-in-rte.rst
@@ -30,7 +30,7 @@ Basic Setup and Configuration
 
 #. Create the component template.  From the content model definition, go to the **Properties Explorer** panel and select the **Display Template** field.  Click on the pencil which will open a **Create Template** dialog.  Provide a filename for the template then it will open a blank template that we can then fill in with the following:
 
-   .. code-block:: guess
+   .. code-block:: html
 
       <h1>${model.greetingText}</h1>
 

--- a/source/developers/cook-books/how-tos/migrate-site-to-elasticsearch.rst
+++ b/source/developers/cook-books/how-tos/migrate-site-to-elasticsearch.rst
@@ -259,13 +259,13 @@ date math syntax described `here <https://www.elastic.co/guide/en/elasticsearch/
 
 **Example**
 
-.. code-block:: guess
+.. code-block:: text
   :linenos:
   :caption: Solr date math expression
 
   createdDate_dt: [ NOW-1MONTH/DAY TO NOW-2DAYS/DAY ]
 
-.. code-block:: guess
+.. code-block:: text
   :linenos:
   :caption: Elasticsearch date math expression
 
@@ -277,13 +277,13 @@ feature that replaces those fields `Multi-match query <https://www.elastic.co/gu
 
 **Example**
 
-.. code-block:: guess
+.. code-block:: text
   :linenos:
   :caption: Solr query for any field
 
   _text_: some keywords
 
-.. code-block:: guess
+.. code-block:: text
   :linenos:
   :caption: Elasticsearch query for any field (replacement for ``_text_``)
 
@@ -297,7 +297,7 @@ feature that replaces those fields `Multi-match query <https://www.elastic.co/gu
 
 Elasticsearch also offers the possibility to query fields with postfixes using wildcards
 
-.. code-block:: guess
+.. code-block:: text
   :linenos:
   :caption: Elasticsearch query for specific fields (replacement for ``_text_main_``)
 

--- a/source/developers/cook-books/how-tos/setting-up-an-ldap-server-for-dev.rst
+++ b/source/developers/cook-books/how-tos/setting-up-an-ldap-server-for-dev.rst
@@ -111,7 +111,7 @@ The server we setup earlier does not have any data yet.  We will now load some d
 
 An empty file in the middle of your ApacheDS will appear.  This is the LDIF editor.  We will now enter some data into it to create users that Crafter Studio can authenticate through the LDAP Server we just setup.  We will add three users, each belonging to a different group for the site **myawesomesite** in Crafter Studio.  Please make sure that the attributes listed in the Crafter Studio LDAP configuration is configured in the LDAP server for each user.  Copy and paste the data listed below into the LDIF editor.  Make sure that there is an empty line after the last entry.
 
-.. code-block:: guess
+.. code-block:: text
     :linenos:
 
     dn: dc=example,dc=com
@@ -182,7 +182,7 @@ An empty file in the middle of your ApacheDS will appear.  This is the LDIF edit
 
 Please note that a user can belong to multiple groups. To add another groupName value in the ldif file, just add another line specifying the attribute and the value. Notice the multiple values for the attribute **ou** (groupName)
 
-.. code-block:: guess
+.. code-block:: text
     :linenos:
 
     dn: cn=John Wick,ou=Users,dc=example,dc=com

--- a/source/developers/cook-books/how-tos/working-with-crafter-studios-api.rst
+++ b/source/developers/cook-books/how-tos/working-with-crafter-studios-api.rst
@@ -31,7 +31,7 @@ Let's begin:
    We’ll use the authenticate API
    :ref:`crafter-studio-api-security-login`
 
-   .. code-block:: guess
+   .. code-block:: bash
 
        curl -d '{"username":"admin","password":"admin"}' --cookie "XSRF-TOKEN=A_VALUE" --header "X-XSRF-TOKEN:A_VALUE" --header "Content-Type: application/json" -v -X POST http://localhost:8080/studio/api/1/services/api/1/security/login.json
 
@@ -43,7 +43,7 @@ Let's begin:
 
    After issuing the CURL command you will get back a response:
 
-   .. code-block:: guess
+   .. code-block:: text
       :linenos:
 
       * Trying ::1...
@@ -81,7 +81,7 @@ Let's begin:
    We'll get a list of sites the user is authorized to work with
    :ref:`crafter-studio-api-site-get-per-user`
 
-   .. code-block:: guess
+   .. code-block:: bash
 
       curl --cookie "XSRF-TOKEN=A_VALUE;JSESSIONID=2E114725C82F3EE44ADC04B578A3BE8F" -H "X-XSRF-TOKEN:A_VALUE"  -X GET http://localhost:8080/studio/api/1/services/api/1/site/get-per-user.json?username=admin
 
@@ -90,7 +90,7 @@ Let's begin:
    Note the CURL command contains your session ID and XSRF tokens.
    After issuing the CURL command you will get a response that contains sites your user has access to:
 
-   .. code-block:: guess
+   .. code-block:: json
 
       {"sites":[{"id":9,"siteId":"ar","name":"ar","description":"","status":null,"liveUrl":null,"lastCommitId":"951004363449cc83209f307b1e9f110dab37fed7","publishingEnabled":1,"publishingStatusMessage":"idle|Idle","lastVerifiedGitlogCommitId":null},{"id":5,"siteId":"diiot","name":"diiot","description":"","status":null,"liveUrl":null,"lastCommitId":"92d543eaa164b1ebfbdd6ce538ae028d4d6421b7","publishingEnabled":0,"publishingStatusMessage":"idle|Idle","lastVerifiedGitlogCommitId":"92d543eaa164b1ebfbdd6ce538ae028d4d6421b7"},{"id":10,"siteId":"editorialcom","name":"editorialcom","description":"","status":null,"liveUrl":null,"lastCommitId":"503d922f226e8ab821073e23ef5a229f907212a0","publishingEnabled":1,"publishingStatusMessage":"","lastVerifiedGitlogCommitId":"503d922f226e8ab821073e23ef5a229f907212a0"},{"id":3,"siteId":"flow","name":"flow","description":"","status":null,"liveUrl":null,"lastCommitId":"21923775c3a1fc778a364d47884b9ee2bb4928a5","publishingEnabled":1,"publishingStatusMessage":"idle|Idle","lastVerifiedGitlogCommitId":"21923775c3a1fc778a364d47884b9ee2bb4928a5"},{"id":8,"siteId":"vr","name":"vr","description":"","status":null,"liveUrl":null,"lastCommitId":"c67fd9dd25d1aa59ff13e3fda2a4387be50dfc69","publishingEnabled":1,"publishingStatusMessage":"idle|Idle","lastVerifiedGitlogCommitId":null}],"total":6}
 
@@ -103,7 +103,7 @@ Let's begin:
    We'll now write content to the Editorial com Project
    :ref:`crafter-studio-api-content-write-content`
 
-   .. code-block:: guess
+   .. code-block:: bash
 
       curl -d "<page><content-type>/page/category-landing</content-type><display-template>/templates/web/pages/category-landing.ftl</display-template><merge-strategy>inherit-levels</merge-strategy><file-name>index.xml</file-name><folder-name>test3</folder-name><internal-name>test3</internal-name><disabled >false</disabled></page>" --cookie "XSRF-TOKEN=A_VALUE;JSESSIONID=2E114725C82F3EE44ADC04B578A3BE8F" -H "X-XSRF-TOKEN:A_VALUE"  -X POST "http://localhost:8080/studio/api/1/services/api/1/content/write-content.json?site=editorialcom&phase=onSave&path=/site/website/test3/index.xml&fileName=index.xml&user=admin&contentType=/page/category-landing&unlock=true"
 

--- a/source/developers/cook-books/how-tos/working-with-dates-freemarker.rst
+++ b/source/developers/cook-books/how-tos/working-with-dates-freemarker.rst
@@ -28,7 +28,7 @@ Using Freemarker Date Built-ins
 -------------------------------
 To display just the date, no time, on when the article was created, we can access the contentModel variable ``date_dt``, and add to the template under the author:
 
-.. code-block:: guess
+.. code-block:: html
 
     <h1>${contentModel.subject!""}</h1>
     <h2>by ${contentModel.author!""}</h2>
@@ -42,42 +42,43 @@ Which will display the following::
 
 To display the date and time:
 
-.. code-block:: guess
+.. code-block:: html
+   :force:
 
     <h3>${contentModel.date_dt?datetime}</h3}
 
 
 Which will output this:
 
-.. code-block:: guess
+.. code-block:: text
 
     2016-12-28T05:00:00.000Z
 
 
 To display the date and time with some formatting:
 
-.. code-block:: guess
+.. code-block:: html
 
     <h3>${contentModel.date_dt?datetime?string["EEEE, MMMM dd, yyyy, hh:mm a '('zzz')'"]}</h3>
 
 
 Which will output this:
 
-.. code-block:: guess
+.. code-block:: text
 
     Wednesday, December 28, 2016, 05:00 AM (UTC)
 
 
 As you can see from the last two examples, the date and time the article was created is in UTC.  If we want to display it in the time zone specified in the `Engine Site Configuration` file, do the following:
 
-.. code-block:: guess
+.. code-block:: html
 
     <h3>${contentModel.date_dt?datetime?iso(siteConfig.getString("timeZone"))}</h3>
 
 
 Which will output this:
 
-.. code-block:: guess
+.. code-block:: text
 
      2016-12-27T21:00:00-08:00
 
@@ -88,28 +89,30 @@ Using the Freemarker time_zone and date_time Setting
 
 If we want to set the time zone used by the template to display dates, Freemarker provides a ``time_zone`` setting.  Once you set the time zone, all date displays will be in the time zone specified.  Let's set all the date and time display in the time zone we specified in the `Engine Site Config` file.
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
 
     <#setting time_zone = siteConfig.getString("timeZone")>
     <h3>${contentModel.date_dt?datetime}</h3>
 
 Which will display:
 
-.. code-block:: guess
+.. code-block:: text
 
     2016-12-27T21:00:00.000-08
 
 
 If we want all date and time displays to follow a certain format, we can use the ``datetime_format`` setting.
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
 
     <#setting datetime_format = "EEEE, MMMM dd, yyyy, hh:mm a '('zzz')'">
 
 
 Which will display the same time as the previous example, but in the format specified:
 
-.. code-block:: guess
+.. code-block:: text
 
     Tuesday, December 27, 2016, 09:00 PM (PST)
 

--- a/source/developers/cook-books/how-tos/working-with-dates-groovy.rst
+++ b/source/developers/cook-books/how-tos/working-with-dates-groovy.rst
@@ -33,7 +33,7 @@ To format the date to a certain format pattern, which we then pass to a template
 
 Which will output this:
 
-.. code-block:: guess
+.. code-block:: text
 
     Tuesday, December 27, 2016, 09:00 PM (PST)
 
@@ -47,7 +47,7 @@ To format the date for a certain format pattern and time zone, do the following:
 
 Which will output this:
 
-.. code-block:: guess
+.. code-block:: text
 
     Wednesday, December 28, 2016, 12:00 AM (EST)
 
@@ -59,7 +59,7 @@ Let's show another example of formatting the date for a certain format pattern a
 
 Which will output this:
 
-.. code-block:: guess
+.. code-block:: text
 
     Tue, December 27, 2016, 09:00 PM (PST)
 
@@ -80,7 +80,7 @@ To convert a date string into a date object (so you can perform date arithmetic,
 
 Which will output this for ``nowDate``:
 
-.. code-block:: guess
+.. code-block:: text
 
     Thu Oct 26 23:45:23 PDT 2017
 
@@ -102,7 +102,7 @@ Say, we want to find the date object 10 days after the date in our example above
 
 Both ``addDate`` and ``addDate2``, will output:
 
-.. code-block:: guess
+.. code-block:: text
 
     Sun Nov 05 23:45:23 PST 2017
 
@@ -115,7 +115,7 @@ Now, if we want to find out the date object 30 days before the date in our examp
 
 Both ``subDate`` and ``subDate2`` will output:
 
-.. code-block:: guess
+.. code-block:: text
 
     Tue Sep 26 23:45:23 PDT 2017
 

--- a/source/developers/cook-books/how-tos/working-with-filters.rst
+++ b/source/developers/cook-books/how-tos/working-with-filters.rst
@@ -23,7 +23,7 @@ Let’s start simple. We’ll create a controller that prints a message before p
 
 Here’s the code:
 
-    .. code-block:: guess
+    .. code-block:: groovy
 
        logger.info("Handling the request")
        filterChain.doFilter(request, response)

--- a/source/developers/developer-workflow/implementation-devops-workflow.rst
+++ b/source/developers/developer-workflow/implementation-devops-workflow.rst
@@ -51,7 +51,7 @@ To create a branch you use the following GitFlow command:
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(master) git flow init
@@ -88,7 +88,7 @@ To create a branch you use the following GitFlow command:
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(master) git flow feature start MYFEATURE
@@ -116,7 +116,7 @@ To publish a branch you use the following GitFlow command
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(feature/MYFEATURE) git flow feature publish MYFEATURE
@@ -167,7 +167,7 @@ To get branch you use the following GitFlow command
 
 Example:
 
-.. code-block:: guess
+.. code-block:: text
     :linenos:
 
     ➜  sandbox git:(feature/MYFEATURE) git flow feature pull origin MYFEATURE
@@ -212,7 +212,7 @@ To push your updates to the Remote Code Repository you use the following Git com
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(feature/MYFEATURE) git push origin feature/MYFEATURE
@@ -280,7 +280,7 @@ To complete the squash of multiple commits into a single commit use the followin
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(feature/MYFEATURE) ✗ git commit -m "Combining all MYFEATURE Commits in to a single Commit ID"
@@ -299,7 +299,7 @@ To rebase the squashed commit at the tip of the Remote Code Repository use the f
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(feature/MYFEATURE) ✗ git commit -m "Combining all MYFEATURE Commits in to a single Commit ID"
@@ -318,7 +318,7 @@ To push the rebased commit up to the Remote Code Repository use the following Gi
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(feature/MYFEATURE) git push origin feature/MYFEATURE
@@ -348,7 +348,7 @@ To cherry pick the squashed feature commit use the following Git command:
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(evn-x) git cherry-pick 294235aa042c7dadd84ecd6b33ce7d02818c291d
@@ -373,7 +373,7 @@ To finalize a feature branch use the following GitFlow command:
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(feature/MYFEATURE) git flow feature finish MYFEATURE
@@ -400,7 +400,7 @@ To push the finalized work up to the remote repository use the following Git com
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(develop) git push origin develop
@@ -426,7 +426,7 @@ To push the branch removal up to the remote repository use the following Git com
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(develop) git push origin develop
@@ -455,7 +455,7 @@ To create a release branch use the following GitFlow command:
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(develop) git flow release start 1.2.0
@@ -483,7 +483,7 @@ To push the new branch to the Remote Code Repository use the following Git comma
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(release/1.2.0) git flow release publish 1.2.0
@@ -526,7 +526,7 @@ To finalize the release use the following GitFlow command:
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(master) git flow  release finish 1.2.0
@@ -550,7 +550,7 @@ To push the finalized release to the Remote Code Repository use the following Gi
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(master) git push origin master
@@ -571,7 +571,7 @@ Now make sure Develop has the latest release.  Ideally there is no real update h
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(master) git push origin develop
@@ -585,7 +585,7 @@ The finalize command creates a release tag for you locally.  Push this release t
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(master) git push origin --tags
@@ -605,7 +605,7 @@ Finally, the release branch was removed locally when it was finalized.  Push the
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(master) git push origin :release/1.2.0

--- a/source/developers/in-context-editing-ftl.rst
+++ b/source/developers/in-context-editing-ftl.rst
@@ -27,7 +27,8 @@ Studio support contains various tools that allow developers to integrate and ena
 
      Search for ``siteContext.overlayCallback`` calls in your ``cstudio-support.ftl`` file:
 
-     .. code-block:: guess
+     .. code-block:: html
+        :force:
         :caption: cstudio-support.ftl
         :emphasize-lines: 2
 
@@ -41,7 +42,8 @@ Studio support contains various tools that allow developers to integrate and ena
 
      Replace with ``modePreview`` to check if Engine is running in preview mode:
 
-     .. code-block:: guess
+     .. code-block:: html
+        :force:
         :caption: cstudio-support.ftl
         :emphasize-lines: 2
 
@@ -59,7 +61,8 @@ Enabling Authoring Support
 
 At the top of your page or component (whatever it is you are rendering, include the following) import:
 
-    .. code-block:: guess
+    .. code-block:: html
+       :force:
 
 	    <#import "/templates/system/common/cstudio-support.ftl" as studio/>
 
@@ -67,7 +70,8 @@ At the top of your page or component (whatever it is you are rendering, include 
 
 At the bottom of your template insert the following: (Note the example shows a traditional HTML page however other formats/levels of granularity are supported
 
-    .. code-block:: guess
+    .. code-block:: html
+       :force:
 
 	        <@studio.toolSupport/>
 	      </body>
@@ -90,7 +94,8 @@ In context editing renders pencils on the screen that invoke editing controls wh
 
 To enable in-context editing simply add the following attribute to the container/element where you want to place the editing control
 
-    .. code-block:: guess
+    .. code-block:: html
+        :force:
 
 	    <@studio.iceAttr component=contentModel iceGroup="author"/>
 
@@ -119,7 +124,8 @@ Tag Attributes
 
 Example: 
 
-    .. code-block:: guess
+    .. code-block:: html
+        :force:
 
 	    <img <@studio.iceAttr iceGroup="image" label="Promo Image 1" /> src="${contentModel.image!""}" alt="${contentModel.alttext!""}"/>``
 
@@ -137,7 +143,8 @@ Drag and drop makes it easy for authors to visually assemble pages.  Authors sim
 
 To define a drop zone for components simply add the ``componentContainerAttr`` attribute with the ``component`` tag to the container element where you want your components to render
 
-    .. code-block:: guess
+    .. code-block:: html
+        :force:
 
 	    <@studio.componentContainerAttr target="bottomPromos" component=contentModel />
 
@@ -158,7 +165,8 @@ Tag Attributes
 
 Example:
 
-    .. code-block:: guess
+    .. code-block:: html
+        :force:
 
 	    <div class="span4 mb10" <@studio.componentContainerAttr target="bottomPromos" component=contentModel /> >
 		    ...
@@ -173,7 +181,8 @@ Rendering components from the target inside the container
 
 The template needs to render the components that are referenced. The basic code to do this looks like:
 
-    .. code-block:: guess
+    .. code-block:: html
+        :force:
 
 	    <#if contentModel.bottomPromos?? && contentModel.bottomPromos.item??>
 		  <#list contentModel.bottomPromos1.item as module>
@@ -186,7 +195,8 @@ The template needs to render the components that are referenced. The basic code 
 Note that the code is simply iterating over the collection of objects and calling render component.  NO markup is being inserted in this example.  The component template is rendering itself.  It's up to you if you want to insert markup around sub-components.
 Full example of typical component drop zone
 
-    .. code-block:: guess
+    .. code-block:: html
+        :force:
 
 	    <div class="span4 mb10" <@studio.componentContainerAttr target="bottomPromos" /> >
 		  <#if contentModel.bottomPromos?? && contentModel.bottomPromos.item??>
@@ -200,7 +210,8 @@ Full example of typical component drop zone
 
 If the component to be rendered is an embedded component, the tag ``parent`` with a |SiteItem| object for the value needs to be added to ``renderComponent`` if the component to be rendered is not the current item, like below:
 
-    .. code-block:: guess
+    .. code-block:: html
+       :force:
 
        <@renderComponent component=module parent=contentModel/>
 
@@ -208,7 +219,8 @@ If the component to be rendered is an embedded component, the tag ``parent`` wit
 
 Let's take a look at an example using a site created using the Website Editorial blueprint.  In the Home page of the site, the features section contains embedded components ``feature``.  To render the embedded components from the target inside the container, note that the tag ``parent=contentModel`` is not required since the component to be rendered is the current item:
 
-.. code-block:: guess
+.. code-block:: html
+   :force:
    :linenos:
    :emphasize-lines: 9
    :caption: */templates/web/pages/home.ftl*
@@ -237,7 +249,8 @@ Identifying components in the template
 
 In order for authors to interact with components, to drag them around the screen for example the templating system must know how to identify them.  To identify a component simply add the following attribute to the outer most element in the component template's markup
 
-    .. code-block:: guess
+    .. code-block:: html
+        :force:
 
 	    <@studio.componentAttr component=contentModel />
 
@@ -269,7 +282,8 @@ Tag Attributes
 
 Example
 
-    .. code-block:: guess
+    .. code-block:: html
+        :force:
 
 	    <img <@studio.componentAttr component=contentModel ice=true /> src="${contentModel.image!""}" alt="${contentModel.alttext!""}" />
 
@@ -290,7 +304,8 @@ Here's how the features section pencils look like before enabling pencils on the
 
 To enable the in-context editing pencils of the features component, add the attribute tag ``ice`` with the value set to ``true`` like below:
 
-.. code-block:: guess
+.. code-block:: html
+   :force:
    :caption: /templates/web/components/feature.ftl
 
    <article <@studio.componentAttr component=contentModel ice=true />>
@@ -312,7 +327,8 @@ Engine Support
 
 At the top of your page or component (whatever it is you are rendering, include the following) import:
 
-    .. code-block:: guess
+    .. code-block:: html
+        :force:
 
 	    <#import "/templates/system/common/crafter-support.ftl" as crafter/>
 
@@ -326,7 +342,8 @@ Render Component
 
 Need to render a sub component of some kind? 
 
-    .. code-block:: guess
+    .. code-block:: html
+        :force:
 
 	    <@renderComponent component=module />
 
@@ -338,7 +355,8 @@ Render Components
 Need to iterate through a list of components and render them WITHOUT any additional markup?
 
 
-    .. code-block:: guess
+    .. code-block:: html
+        :force:
 
 	    <@crafter.renderComponents componentList=contentModel.bottomPromos />
 

--- a/source/developers/projects/core/api/content_store/children.rst
+++ b/source/developers/projects/core/api/content_store/children.rst
@@ -42,7 +42,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: text
 
   GET .../api/1/content_store/children.json?contextId=405ffc233d075b010536bd2eb786b86c&url=/site/website
 

--- a/source/developers/projects/core/api/content_store/descriptor.rst
+++ b/source/developers/projects/core/api/content_store/descriptor.rst
@@ -41,7 +41,7 @@ Example
 ^^^^^^^
 Request
 ^^^^^^^
-.. code-block:: guess
+.. code-block:: text
 
   GET .../api/1/content_store/descriptor.json?contextId=405ffc233d075b010536bd2eb786b86c&url=/site/website/index.xml
 

--- a/source/developers/projects/core/api/content_store/item.rst
+++ b/source/developers/projects/core/api/content_store/item.rst
@@ -41,7 +41,7 @@ Example
 ^^^^^^^
 Request
 ^^^^^^^
-.. code-block:: guess
+.. code-block:: text
 
   GET .../api/1/content_store/item.json?contextId=405ffc233d075b010536bd2eb786b86c&url=/site/website/index.xml
 

--- a/source/developers/projects/core/api/content_store/tree.rst
+++ b/source/developers/projects/core/api/content_store/tree.rst
@@ -44,7 +44,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: text
 
  GET .../api/1/content_store/tree.xml?contextId=405ffc233d075b010536bd2eb786b86c&url=/site/website/articles/2017
 

--- a/source/developers/projects/engine/api/index.rst
+++ b/source/developers/projects/engine/api/index.rst
@@ -13,7 +13,7 @@ Crafter Engine API
 
     Here's an example to get an Item from the content store:
 
-    .. code-block:: guess
+    .. code-block:: text
 
         http://localhost:8080/api/1/site/content_store/item.json?url=/site/website/index.xml&crafterSite=mysite
 

--- a/source/developers/projects/engine/api/templating-api.rst
+++ b/source/developers/projects/engine/api/templating-api.rst
@@ -31,7 +31,8 @@ Rendering Navigation
 Crafter Engine provides the option of rendering automatically the navigation for you, just by using the macro
 ``renderNavigation``:
 
-.. code-block:: guess
+.. code-block:: html
+  :force:
   :linenos:
   :caption: Using the Navigation Macro
 
@@ -58,7 +59,8 @@ Rendering Breadcrumbs
 Crafter also offers a ``renderBreadcrumb`` macro to easily generate a dynamic list with all the
 parent pages of a specific url.
 
-.. code-block:: guess
+.. code-block:: html
+  :force:
   :linenos:
   :caption: Using the Breadcrumb Macro
 
@@ -91,7 +93,8 @@ Engine includes a default implementation that can be found in ``templates/web/na
 and ``templates/web/navigation2/breadcrumb-macros.ftl`` but it also provides the option to use your
 own sets of macros, which you'll probably want since the navigation HTML is generally specific to the site.
 
-.. code-block:: guess
+.. code-block:: html
+  :force:
   :linenos:
   :caption: Default Nav Macros
 
@@ -125,7 +128,8 @@ own sets of macros, which you'll probably want since the navigation HTML is gene
      </li>
   </#macro>
 
-.. code-block:: guess
+.. code-block:: html
+  :force:
   :linenos:
   :caption: Default Breadcrumb Macros
 
@@ -140,7 +144,8 @@ own sets of macros, which you'll probably want since the navigation HTML is gene
 You can define your own macros in an additional Freemarker template and include and optional
 parameter with the namespace that was given in the ``import`` tag:
 
-.. code-block:: guess
+.. code-block:: html
+  :force:
   :linenos:
   :caption: Using Custom Navigation Macros
 
@@ -179,7 +184,8 @@ Running Scripts/Controllers
 
 Crafter Engine allows executing scripts/controllers from inside Freemarker templates by using the tag ``@crafter.controller``.  It requires a single parameter, ``path``, which is the path of the script/controller in the site:
 
-.. code-block:: guess
+.. code-block:: html
+   :force:
    :caption: Running Scripts/Controllers from inside Freemarker templates
 
    <@crafter.controller path=“/scripts/plugins/MyPlugin/1/get-tweets.groovy” />

--- a/source/developers/projects/profile/api/profile/attachment/all.rst
+++ b/source/developers/projects/profile/api/profile/attachment/all.rst
@@ -43,7 +43,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
   GET .../api/1/profile/59284659d4c650213cc2f3fc/attachments?accessTokenId=e8f5170c-877b-416f-b70f-4b09772f8e2d
 

--- a/source/developers/projects/profile/api/profile/attachment/details.rst
+++ b/source/developers/projects/profile/api/profile/attachment/details.rst
@@ -45,7 +45,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
   GET .../api/1/profile/59284659d4c650213cc2f3fc/attachment/picture1/details?accessTokenId=e8f5170c-877b-416f-b70f-4b09772f8e2d
 

--- a/source/developers/projects/profile/api/profile/attachment/get.rst
+++ b/source/developers/projects/profile/api/profile/attachment/get.rst
@@ -45,7 +45,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
   GET .../api/1/profile/59284659d4c650213cc2f3fc/attachment/picture1?accessTokenId=e8f5170c-877b-416f-b70f-4b09772f8e2d
 

--- a/source/developers/projects/profile/api/profile/attributes/get.rst
+++ b/source/developers/projects/profile/api/profile/attributes/get.rst
@@ -47,7 +47,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
   GET .../api/1/profile/592887d7d4c650213cc2f400/attributes?accessTokenId=e8f5170c-877b-416f-b70f-4b09772f8e2d
 

--- a/source/developers/projects/profile/api/profile/create.rst
+++ b/source/developers/projects/profile/api/profile/create.rst
@@ -60,7 +60,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
   POST .../api/1/profile/create
 

--- a/source/developers/projects/profile/api/profile/verification_token/create.rst
+++ b/source/developers/projects/profile/api/profile/verification_token/create.rst
@@ -47,7 +47,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
   POST .../api/1/profile/592715d4d4c650e226b03b62/verification_token/create?accessTokenId=e8f5170c-877b-416f-b70f-4b09772f8e2d
 

--- a/source/developers/projects/profile/api/profile/verification_token/delete.rst
+++ b/source/developers/projects/profile/api/profile/verification_token/delete.rst
@@ -47,7 +47,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
   POST .../api/1/profile/verification_token/de60f56d-3a4b-4dec-b798-fb22b2964c14/delete?accessTokenId=e8f5170c-877b-416f-b70f-4b09772f8e2d
 

--- a/source/developers/projects/profile/api/profile/verification_token/get.rst
+++ b/source/developers/projects/profile/api/profile/verification_token/get.rst
@@ -43,7 +43,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
   GET .../api/1/profile/verification_token/de60f56d-3a4b-4dec-b798-fb22b2964c14?accessTokenId=e8f5170c-877b-416f-b70f-4b09772f8e2d
 

--- a/source/developers/projects/search/api/search/v2/update-content.rst
+++ b/source/developers/projects/search/api/search/v2/update-content.rst
@@ -55,7 +55,7 @@ Request
 
   POST .../api/2/search/update-content
 
-.. code-block:: guess
+.. code-block:: none
 
   index_id = editorial
   site = editorial

--- a/source/developers/projects/social/api/v3/system/context/add-profile.rst
+++ b/source/developers/projects/social/api/v3/system/context/add-profile.rst
@@ -51,7 +51,7 @@ Request
 
   POST .../api/3/system/context/e41e7273-b504-4d50-9edd-3b215eff6464/596683c030047dc279c21d27
 
-.. code-block:: guess
+.. code-block:: none
 
   context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
   roles=SOCIAL_USER

--- a/source/developers/projects/social/api/v3/system/context/create.rst
+++ b/source/developers/projects/social/api/v3/system/context/create.rst
@@ -46,7 +46,7 @@ Request
 
   POST .../api/3/system/context?context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
 
-.. code-block:: guess
+.. code-block:: none
 
   contextName=site1
 

--- a/source/developers/projects/social/api/v3/system/context/preferences-delete.rst
+++ b/source/developers/projects/social/api/v3/system/context/preferences-delete.rst
@@ -46,7 +46,7 @@ Request
 
   POST .../api/3/system/context/deletePreferences
 
-.. code-block:: guess
+.. code-block:: none
 
   context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
   preferences=customPref

--- a/source/developers/projects/social/api/v3/system/context/preferences-email-config-update.rst
+++ b/source/developers/projects/social/api/v3/system/context/preferences-email-config-update.rst
@@ -68,7 +68,7 @@ Request
 
   POST .../api/3/system/context/preferences/email/config
 
-.. code-block:: guess
+.. code-block:: none
 
   context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
   password=passw0rd

--- a/source/developers/projects/social/api/v3/system/context/preferences-email-template-update.rst
+++ b/source/developers/projects/social/api/v3/system/context/preferences-email-template-update.rst
@@ -57,7 +57,7 @@ Request
 
   POST .../api/3/system/context/preferences/email
 
-.. code-block:: guess
+.. code-block:: none
 
   template=Sample template for email
   type=INSTANT

--- a/source/developers/projects/social/api/v3/system/context/preferences-update.rst
+++ b/source/developers/projects/social/api/v3/system/context/preferences-update.rst
@@ -49,7 +49,7 @@ Request
 
   POST .../api/3/system/context/updatePreference
 
-.. code-block:: guess
+.. code-block:: none
 
   context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
   moderateByMailEnable=true

--- a/source/developers/projects/social/api/v3/system/context/remove-profile.rst
+++ b/source/developers/projects/social/api/v3/system/context/remove-profile.rst
@@ -48,7 +48,7 @@ Request
 
   POST .../api/3/system/context/e41e7273-b504-4d50-9edd-3b215eff6464/596683c030047dc279c21d27/delete
 
-.. code-block:: guess
+.. code-block:: none
 
   context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
 

--- a/source/developers/projects/social/api/v3/ugc/attachments/create.rst
+++ b/source/developers/projects/social/api/v3/ugc/attachments/create.rst
@@ -48,7 +48,7 @@ Request
 
   POST .../api/3/comments/59678d3f300426156e21df50/attachments?context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
 
-.. code-block:: guess
+.. code-block:: none
 
   Binary content
 

--- a/source/developers/projects/social/api/v3/ugc/comments/create.rst
+++ b/source/developers/projects/social/api/v3/ugc/comments/create.rst
@@ -60,7 +60,7 @@ Request
 
   POST .../api/3/comments
 
-.. code-block:: guess
+.. code-block:: none
 
   context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
   body=This is the first comment!

--- a/source/developers/projects/social/api/v3/ugc/comments/delete-attributes.rst
+++ b/source/developers/projects/social/api/v3/ugc/comments/delete-attributes.rst
@@ -56,7 +56,7 @@ Request
 
   DELETE .../api/3/comments/59678d3f300426156e21df50/attributes?context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
 
-.. code-block:: guess
+.. code-block:: none
 
   attributes=custom.property,second.property
 

--- a/source/developers/projects/social/api/v3/ugc/comments/moderate.rst
+++ b/source/developers/projects/social/api/v3/ugc/comments/moderate.rst
@@ -48,7 +48,7 @@ Request
 
   PUT .../api/3/comments/59678d3f300426156e21df50/moderate?context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
 
-.. code-block:: guess
+.. code-block:: none
 
   status=APPROVED
 

--- a/source/developers/projects/social/api/v3/ugc/comments/search.rst
+++ b/source/developers/projects/social/api/v3/ugc/comments/search.rst
@@ -52,7 +52,7 @@ Request
 
   POST .../api/3/comments/search
 
-.. code-block:: guess
+.. code-block:: none
 
   context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
   search={ targetId: "Welcome" }

--- a/source/developers/projects/social/api/v3/ugc/comments/update-attributes.rst
+++ b/source/developers/projects/social/api/v3/ugc/comments/update-attributes.rst
@@ -50,7 +50,7 @@ Request
 
   PUT .../api/3/comments/59678d3f300426156e21df50?context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
 
-.. code-block:: guess
+.. code-block:: none
 
   customProperty=true
 

--- a/source/developers/projects/social/api/v3/ugc/comments/update-flags.rst
+++ b/source/developers/projects/social/api/v3/ugc/comments/update-flags.rst
@@ -48,7 +48,7 @@ Request
 
   POST .../api/3/comments/59678d3f300426156e21df50/flags?context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
 
-.. code-block:: guess
+.. code-block:: none
 
   reason=Contains offensive language
 

--- a/source/developers/projects/social/api/v3/ugc/comments/update.rst
+++ b/source/developers/projects/social/api/v3/ugc/comments/update.rst
@@ -59,7 +59,7 @@ Request
 
   PUT .../api/3/comments/59678d3f300426156e21df50?context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
 
-.. code-block:: guess
+.. code-block:: none
 
 	body=This was the first comment in the site!
 

--- a/source/developers/projects/social/api/v3/ugc/threads/subscribe-update.rst
+++ b/source/developers/projects/social/api/v3/ugc/threads/subscribe-update.rst
@@ -55,7 +55,7 @@ Request
 
   POST .../api/3/threads/Welcome/subscribe/update
 
-.. code-block:: guess
+.. code-block:: none
 
   context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
   frequency=daily

--- a/source/developers/projects/social/api/v3/ugc/threads/subscribe.rst
+++ b/source/developers/projects/social/api/v3/ugc/threads/subscribe.rst
@@ -55,7 +55,7 @@ Request
 
   POST .../api/3/threads/Welcome/subscribe
 
-.. code-block:: guess
+.. code-block:: none
 
   context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
   frequency=weekly

--- a/source/developers/projects/social/api/v3/ugc/threads/unsubscribe.rst
+++ b/source/developers/projects/social/api/v3/ugc/threads/unsubscribe.rst
@@ -46,7 +46,7 @@ Request
 
   DELETE .../api/3/threads/Welcome/unsubscribe
 
-.. code-block:: guess
+.. code-block:: none
 
   context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
 

--- a/source/developers/projects/social/api/v3/ugc/votes/vote-down.rst
+++ b/source/developers/projects/social/api/v3/ugc/votes/vote-down.rst
@@ -46,7 +46,7 @@ Request
 
   PUT .../api/3/comments/59678d3f300426156e21df50/votes/down
 
-.. code-block:: guess
+.. code-block:: none
 
   context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
 

--- a/source/developers/projects/social/api/v3/ugc/votes/vote-neutral.rst
+++ b/source/developers/projects/social/api/v3/ugc/votes/vote-neutral.rst
@@ -46,7 +46,7 @@ Request
 
   PUT .../api/3/comments/59678d3f300426156e21df50/votes/neutral
 
-.. code-block:: guess
+.. code-block:: none
 
   context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
 

--- a/source/developers/projects/social/api/v3/ugc/votes/vote-up.rst
+++ b/source/developers/projects/social/api/v3/ugc/votes/vote-up.rst
@@ -46,7 +46,7 @@ Request
 
   PUT .../api/3/comments/59678d3f300426156e21df50/votes/up
 
-.. code-block:: guess
+.. code-block:: none
 
   context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
 

--- a/source/developers/projects/studio/api/activity/get-user-activity.rst
+++ b/source/developers/projects/studio/api/activity/get-user-activity.rst
@@ -49,7 +49,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/activity/get-user-activities.json?site_id=mysite&user=jane.doe&num=10&excludeLive=false&filterType=all``
 
@@ -59,7 +59,8 @@ Response
 
 ``Status 200 OK``
 
-.. code-block:: guess
+.. code-block:: json
+  :force:
   :linenos:
 
   {

--- a/source/developers/projects/studio/api/activity/post-activity.rst
+++ b/source/developers/projects/studio/api/activity/post-activity.rst
@@ -49,7 +49,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST .../api/1/services/api/1/activity/post-activity.json?site_id=mysite&user=jane.doe&path=/site/website/index.xml&activity=UPDATE&contentTypeClass=pages``
 
@@ -59,7 +59,7 @@ Response
 
 ``Status 200 OK``
 
-.. code-block:: guess
+.. code-block:: none
 
   No response body
 

--- a/source/developers/projects/studio/api/clipboard/copy-item.rst
+++ b/source/developers/projects/studio/api/clipboard/copy-item.rst
@@ -42,7 +42,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST .../api/1/services/api/1/clipboard/copy-item.json?site_id=mysite
 

--- a/source/developers/projects/studio/api/clipboard/cut-item.rst
+++ b/source/developers/projects/studio/api/clipboard/cut-item.rst
@@ -41,7 +41,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST .../api/1/services/api/1/clipboard/cut-item.json?site_id=mysite
 

--- a/source/developers/projects/studio/api/clipboard/get-items.rst
+++ b/source/developers/projects/studio/api/clipboard/get-items.rst
@@ -42,7 +42,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/clipboard/get-items.json?site_id=mysite
 

--- a/source/developers/projects/studio/api/clipboard/paste-item.rst
+++ b/source/developers/projects/studio/api/clipboard/paste-item.rst
@@ -44,7 +44,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/clipboard/paste-item.json?site_id=mysite&parentPath=/site/website/folder2
 

--- a/source/developers/projects/studio/api/content/change-content-type.rst
+++ b/source/developers/projects/studio/api/content/change-content-type.rst
@@ -46,7 +46,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST .../api/1/services/api/1/content/change-content-type.json?site_id=mysite&path=/site/website/health/index.xml&contentType=/page/generic
 
@@ -56,7 +56,7 @@ Response
 
 ``Status 200 OK``
 
-.. code-block:: guess
+.. code-block:: none
 
     N/A
 

--- a/source/developers/projects/studio/api/content/content-exists.rst
+++ b/source/developers/projects/studio/api/content/content-exists.rst
@@ -44,7 +44,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/content-exists.json?site_id=mysite&path=/site/website/health/index.xml
 

--- a/source/developers/projects/studio/api/content/create-folder.rst
+++ b/source/developers/projects/studio/api/content/create-folder.rst
@@ -46,7 +46,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST .../api/1/services/api/1/content/create-folder.json?site_id=mysite&path=/site/website&name=newFolder
 

--- a/source/developers/projects/studio/api/content/crop-image.rst
+++ b/source/developers/projects/studio/api/content/crop-image.rst
@@ -54,7 +54,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/get-content.json?site_id=mysite&path=/static-assets/images/image1.png&newname=cropped.png&t=10&l=10&w=10&h=10
 
@@ -64,7 +64,7 @@ Response
 
 ``Status 200 OK``
 
-.. code-block:: guess
+.. code-block:: none
 
     { "success":true }
 

--- a/source/developers/projects/studio/api/content/get-content-at-path.rst
+++ b/source/developers/projects/studio/api/content/get-content-at-path.rst
@@ -44,7 +44,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/get-content-at-path.json?site_id=mysite&path=/site/website/health/index.xml
 
@@ -54,7 +54,7 @@ Response
 
 ``Status 200 OK``
 
-.. code-block:: guess
+.. code-block:: none
 
     content
 

--- a/source/developers/projects/studio/api/content/get-content-type.rst
+++ b/source/developers/projects/studio/api/content/get-content-type.rst
@@ -44,7 +44,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/get-content-type.json?site_id=mysite&type=/page/category-landing
 

--- a/source/developers/projects/studio/api/content/get-content-types.rst
+++ b/source/developers/projects/studio/api/content/get-content-types.rst
@@ -44,7 +44,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/get-content-type.jsons?site_id=mysite&type=/site/website
 

--- a/source/developers/projects/studio/api/content/get-content.rst
+++ b/source/developers/projects/studio/api/content/get-content.rst
@@ -46,7 +46,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/get-content.json?site_id=mysite&path=/site/website/health/index.xml&edit=true
 
@@ -56,7 +56,7 @@ Response
 
 ``Status 200 OK``
 
-.. code-block:: guess
+.. code-block:: none
 
     content
 

--- a/source/developers/projects/studio/api/content/get-item-orders.rst
+++ b/source/developers/projects/studio/api/content/get-item-orders.rst
@@ -44,7 +44,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/get-item-orders.json?site_id=mysite&path=/site/website/style/index.xml&edit=true
 

--- a/source/developers/projects/studio/api/content/get-item-states.rst
+++ b/source/developers/projects/studio/api/content/get-item-states.rst
@@ -44,7 +44,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/get-item-states.json?site_id=mysite&state=ALL
 

--- a/source/developers/projects/studio/api/content/get-item-versions.rst
+++ b/source/developers/projects/studio/api/content/get-item-versions.rst
@@ -44,7 +44,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/get-item-versions.json?site_id=mysite&path=/site/website/index.xml
 

--- a/source/developers/projects/studio/api/content/get-item.rst
+++ b/source/developers/projects/studio/api/content/get-item.rst
@@ -44,7 +44,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/get-item.json?site_id=mysite&path=/site/website/index.xml&edit=true
 

--- a/source/developers/projects/studio/api/content/get-items-tree.rst
+++ b/source/developers/projects/studio/api/content/get-items-tree.rst
@@ -46,7 +46,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/get-items-tree.json?site_id=mysite&path=/site/website/index.xml&depth=1
 

--- a/source/developers/projects/studio/api/content/get-next-item-order.rst
+++ b/source/developers/projects/studio/api/content/get-next-item-order.rst
@@ -44,7 +44,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/get-next-item-order.json?site_id=mysite&path=/site/website/index.xml
 

--- a/source/developers/projects/studio/api/content/get-pages.rst
+++ b/source/developers/projects/studio/api/content/get-pages.rst
@@ -48,7 +48,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/get-pages.json?site_id=mysite&path=/site/website/index.xml&depth=1&order=default
 

--- a/source/developers/projects/studio/api/content/rename-folder.rst
+++ b/source/developers/projects/studio/api/content/rename-folder.rst
@@ -46,7 +46,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST .../api/1/services/api/1/content/rename-folder.json?site_id=mysite&path=/site/website/oldFolder&name=newFolder
 

--- a/source/developers/projects/studio/api/content/reorder-items.rst
+++ b/source/developers/projects/studio/api/content/reorder-items.rst
@@ -48,7 +48,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/reorder-items.json?site_id=mysitet&path=/site/website/health/index.xml&before=/site/website/entertainment/index.xml&after=/site/website/technology/index.xml
 

--- a/source/developers/projects/studio/api/content/revert-content.rst
+++ b/source/developers/projects/studio/api/content/revert-content.rst
@@ -46,7 +46,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/revert-content.json?site_id=mysite&path=/site/website/style/index.xml&version=818e0f68bfccda9a9a1a788341b87ca3ba5ad3c6
 

--- a/source/developers/projects/studio/api/content/search.rst
+++ b/source/developers/projects/studio/api/content/search.rst
@@ -62,7 +62,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST ../api/1/services/api/1/content/search.json?site_id=mysite
 

--- a/source/developers/projects/studio/api/content/set-item-state.rst
+++ b/source/developers/projects/studio/api/content/set-item-state.rst
@@ -48,7 +48,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST ../api/1/services/api/1/content/set-item-state.json?site_id=mysite&path=/config/studio/administration/config-list.xml&state=EXISTING_UNEDITED_UNLOCKED&systemprocessing=false
 

--- a/source/developers/projects/studio/api/content/unlock-content.rst
+++ b/source/developers/projects/studio/api/content/unlock-content.rst
@@ -44,7 +44,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/unlock-content.json?site_id=mysite&path=/site/website/technology/index.xml
 

--- a/source/developers/projects/studio/api/content/write-content.rst
+++ b/source/developers/projects/studio/api/content/write-content.rst
@@ -63,13 +63,13 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST ../api/1/services/api/1/content/write-content.json?site_id=mysite&phase=onSave&path=/site/website/index.xml&fileName=index.xml&user=admin&contentType=/page/home&unlock=true
 
 |
 
-.. code-block:: guess
+.. code-block:: xml
     :caption: Request body
 
         <page>
@@ -187,13 +187,14 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST ../api/1/services/api/1/content/write-content.json?site_id=mysite&phase=onSave&path=/templates/web/pages&fileName=home.ftl&user=admin&unlock=true
 
 |
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
     :caption: Request body
 
         <#import "/templates/system/common/cstudio-support.ftl" as studio />
@@ -363,7 +364,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST ../api/1/services/api/1/content/write-content.json?site_id=mysite&phase=onSave&path=/static-assets&fileName=undefined&user=admin&unlock=true
 
@@ -382,7 +383,7 @@ This request needs to be sent with ``Content-Type=multipart/form-data`` with the
 
 Your request payload should look like this:
 
-.. code-block:: guess
+.. code-block:: none
 
    ------WebKitFormBoundaryl9p1lhdx4gWpuCMM
    Content-Disposition: form-data; name="site"

--- a/source/developers/projects/studio/api/dependency/calculate-dependencies.rst
+++ b/source/developers/projects/studio/api/dependency/calculate-dependencies.rst
@@ -40,7 +40,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	POST .../api/1/services/api/1/dependency/calculate-dependencies.json?site_id=mysite
 

--- a/source/developers/projects/studio/api/dependency/get-dependant.rst
+++ b/source/developers/projects/studio/api/dependency/get-dependant.rst
@@ -44,7 +44,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST .../api/1/services/api/1/dependency/get-dependant.json?site_id=mysite&path=/templates/web/pages/home.ftl
 

--- a/source/developers/projects/studio/api/dependency/get-dependencies.rst
+++ b/source/developers/projects/studio/api/dependency/get-dependencies.rst
@@ -40,11 +40,11 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	POST .../api/1/services/api/1/dependency/get-dependencies.json?site_id=mysite
 
-.. code-block:: guess
+.. code-block:: none
 
     [
         {

--- a/source/developers/projects/studio/api/dependency/get-simple-dependencies.rst
+++ b/source/developers/projects/studio/api/dependency/get-simple-dependencies.rst
@@ -40,7 +40,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	POST ../api/1/services/api/1/dependency/get-simple-dependencies.json?site_id=mysite&path=/site/website/index.xml
 

--- a/source/developers/projects/studio/api/deployment/bulk-golive.rst
+++ b/source/developers/projects/studio/api/deployment/bulk-golive.rst
@@ -48,7 +48,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST .../api/1/services/api/1/deployment/bulk-golive.json?site_id=mysite&path=/site/website&environment=Live
 

--- a/source/developers/projects/studio/api/deployment/get-available-publishing-channels.rst
+++ b/source/developers/projects/studio/api/deployment/get-available-publishing-channels.rst
@@ -43,7 +43,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/deployment/get-available-publishing-channels.json?site_id=mysite
 

--- a/source/developers/projects/studio/api/deployment/get-deployment-history.rst
+++ b/source/developers/projects/studio/api/deployment/get-deployment-history.rst
@@ -48,7 +48,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/deployment/get-deployment-history.json?site_id=mysite&days=30&num=10&filterType=all
 

--- a/source/developers/projects/studio/api/deployment/get-scheduled-items.rst
+++ b/source/developers/projects/studio/api/deployment/get-scheduled-items.rst
@@ -48,7 +48,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/deployment/get-scheduled-items.json?site_id=mysite&sort=eventDate&ascending=false&filterType=all
 

--- a/source/developers/projects/studio/api/preview/sync-site.rst
+++ b/source/developers/projects/studio/api/preview/sync-site.rst
@@ -42,7 +42,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST .../api/1/services/api/1/preview/sync-site.json?site_id=mysite
 

--- a/source/developers/projects/studio/api/publish/commits.rst
+++ b/source/developers/projects/studio/api/publish/commits.rst
@@ -48,7 +48,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST .../api/1/services/api/1/publish/commits.json
 

--- a/source/developers/projects/studio/api/publish/publish-items.rst
+++ b/source/developers/projects/studio/api/publish/publish-items.rst
@@ -47,7 +47,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	POST .../api/1/services/api/1/publish/publish-items.json?site_id=mysite
 

--- a/source/developers/projects/studio/api/security/get-user-permissions.rst
+++ b/source/developers/projects/studio/api/security/get-user-permissions.rst
@@ -42,7 +42,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/security/get-user-permissions.json?site_id=mysite&path=/site/website/style/index.xml&user=admin
 

--- a/source/developers/projects/studio/api/security/get-user-roles.rst
+++ b/source/developers/projects/studio/api/security/get-user-roles.rst
@@ -40,7 +40,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/security/get-user-roles.json?site_id=mysite&user=admin
 

--- a/source/developers/projects/studio/api/security/validate-session.rst
+++ b/source/developers/projects/studio/api/security/validate-session.rst
@@ -34,7 +34,7 @@ None.
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/security/validate-session.json
 

--- a/source/developers/projects/studio/api/server/get-available-languages.rst
+++ b/source/developers/projects/studio/api/server/get-available-languages.rst
@@ -29,7 +29,7 @@ Resource Information
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/server/get-available-languages.json
 

--- a/source/developers/projects/studio/api/server/get-loggers.rst
+++ b/source/developers/projects/studio/api/server/get-loggers.rst
@@ -29,7 +29,7 @@ Resource Information
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/server/get-loggers.json
 

--- a/source/developers/projects/studio/api/server/get-ui-resource-override.rst
+++ b/source/developers/projects/studio/api/server/get-ui-resource-override.rst
@@ -39,7 +39,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/server/get-ui-resource-override.json?resource=logo.jpg
 

--- a/source/developers/projects/studio/api/server/set-logger-state.rst
+++ b/source/developers/projects/studio/api/server/set-logger-state.rst
@@ -41,7 +41,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/server/set-logger-state.json?logger=org.craftercms.studio.impl.v1.service.content.ContentServiceImpl&level=debug
 

--- a/source/developers/projects/studio/api/site/clear-configuration-cache.rst
+++ b/source/developers/projects/studio/api/site/clear-configuration-cache.rst
@@ -29,7 +29,7 @@ Resource Information
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/site/clear-configuration-cache.json?site_id=mysite
 

--- a/source/developers/projects/studio/api/site/create-site.rst
+++ b/source/developers/projects/studio/api/site/create-site.rst
@@ -89,7 +89,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	POST .../api/1/services/api/1/site/create.json
 

--- a/source/developers/projects/studio/api/site/delete-site.rst
+++ b/source/developers/projects/studio/api/site/delete-site.rst
@@ -38,7 +38,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	POST .../api/1/services/api/1/site/delete-site.json
 

--- a/source/developers/projects/studio/api/site/exists.rst
+++ b/source/developers/projects/studio/api/site/exists.rst
@@ -38,7 +38,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/site/exists.json?site_id=mysite
 

--- a/source/developers/projects/studio/api/site/get-available-blueprints.rst
+++ b/source/developers/projects/studio/api/site/get-available-blueprints.rst
@@ -28,7 +28,7 @@ Resource Information
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/site/get-available-blueprints.json
 

--- a/source/developers/projects/studio/api/site/get-canned-message.rst
+++ b/source/developers/projects/studio/api/site/get-canned-message.rst
@@ -46,7 +46,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/site/get-canned-message.json?site_id=mysite&locale=en&type=NotApproved
 

--- a/source/developers/projects/studio/api/site/get-configuration.rst
+++ b/source/developers/projects/studio/api/site/get-configuration.rst
@@ -44,7 +44,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/site/get-configuration.json?site_id=mysite&path=/site-config.xml
 

--- a/source/developers/projects/studio/api/site/get-site.rst
+++ b/source/developers/projects/studio/api/site/get-site.rst
@@ -38,7 +38,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/site/get.json?site_id=my-site
 

--- a/source/developers/projects/studio/api/site/get-sites-per-user.rst
+++ b/source/developers/projects/studio/api/site/get-sites-per-user.rst
@@ -42,7 +42,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/site/get-per-user.json?username=jane.doe
 

--- a/source/developers/projects/studio/api/site/monitor-content.rst
+++ b/source/developers/projects/studio/api/site/monitor-content.rst
@@ -29,11 +29,12 @@ Resource Information
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/site/monitor-content.json
 
-.. code-block:: guess
+.. code-block:: json
+   :force:
 
    [
      {

--- a/source/developers/projects/studio/api/site/write-configuration.rst
+++ b/source/developers/projects/studio/api/site/write-configuration.rst
@@ -40,7 +40,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	POST .../api/1/services/api/1/site/write-configuration.json?site_id=mysite&path=/config/studio/site-config.xml
 

--- a/source/developers/projects/studio/api/workflow/create-jobs.rst
+++ b/source/developers/projects/studio/api/workflow/create-jobs.rst
@@ -44,7 +44,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST .../api/1/services/api/1/workflow/create-jobs.json?site_id=mysite&user=test
 

--- a/source/developers/projects/studio/api/workflow/get-go-live-items.rst
+++ b/source/developers/projects/studio/api/workflow/get-go-live-items.rst
@@ -48,7 +48,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/workflow/get-go-live-items.json?site_id=mysite&sort=eventDate&ascending=false
 

--- a/source/developers/projects/studio/api/workflow/get-workflow-affected-paths.rst
+++ b/source/developers/projects/studio/api/workflow/get-workflow-affected-paths.rst
@@ -44,7 +44,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/workflow/get-workflow-affected-paths.json?site_id=mysite&path=/site/website/index.xml
 
@@ -54,7 +54,7 @@ Response
 
 ``Status 200 OK``
 
-.. code-block:: guess
+.. code-block:: none
     :linenos:
 
     {

--- a/source/developers/projects/studio/api/workflow/go-delete.rst
+++ b/source/developers/projects/studio/api/workflow/go-delete.rst
@@ -48,7 +48,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST ../api/1/services/api/1/workflow/go-delete.json?deletedep=true&site_id=mysite&user=admin
 

--- a/source/developers/projects/studio/api/workflow/go-live.rst
+++ b/source/developers/projects/studio/api/workflow/go-live.rst
@@ -42,7 +42,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST .../api/1/services/api/1/workflow/go-live.json?site_id=mysite
 

--- a/source/developers/projects/studio/api/workflow/reject.rst
+++ b/source/developers/projects/studio/api/workflow/reject.rst
@@ -44,7 +44,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST .../api/1/services/api/1/workflow/reject.json?site_id=mysite&user=test
 

--- a/source/developers/projects/studio/api/workflow/submit-to-go-live.rst
+++ b/source/developers/projects/studio/api/workflow/submit-to-go-live.rst
@@ -47,7 +47,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST .../api/1/services/api/1/workflow/submit-to-go-live.json?site_id=mysite&user=author
 

--- a/source/developers/search-elasticsearch.rst
+++ b/source/developers/search-elasticsearch.rst
@@ -130,7 +130,8 @@ This step will change depending on the technology being used to display all info
 or a SPA using Angular, React or Vue. As an example we will use Handlebars templates that will be rendered using
 jQuery.
 
-.. code-block:: guess
+.. code-block:: html
+  :force:
   :linenos:
   :caption: Search result page templates
   

--- a/source/developers/search-solr.rst
+++ b/source/developers/search-solr.rst
@@ -81,7 +81,8 @@ Create template variables with current cookie values
 
 As you can see, the code simply creates a template value for each user selection based on the value from the cookie.  If no cookie is found a default value (specified by !”FOO”) is provided. This code would typically appear close to the top of the template.
 
-.. code-block:: guess
+.. code-block:: html
+   :force:
 
    <#assign sort = (Cookies["category-sort"]!"")?replace("-", " ")>
    <#assign filterSize = (Cookies["category-filter-size"]!"*")>
@@ -92,7 +93,8 @@ Render controls with values selected from cookies
 
 Now we need to build the filter controls for our users so that they can narrow their searches. In the code below we’re iterating over the available options (we’ll show how these are acquired in just a moment) and creating the options for the select component.  For each option we look to see if it is the currently selected item and if so we mark it as selected.
 
-.. code-block:: guess
+.. code-block:: html
+   :force:
    :linenos:
 
    <select style="width: 90px"  onchange="setCookie('category-filter-color', this.value);">
@@ -107,7 +109,8 @@ Provide a  mechanism to save a selected value to our cookie and force a refresh
 
 In the code above you can see a simple JavaScript function on the “onChange” method for the select control.  Again you can see here we’re keeping the code as abstraction free as possible to make the example clear.  Below is the simple JavaScript function:
 
-.. code-block:: guess
+.. code-block:: js
+   :force:
    :linenos:
 
    <script>
@@ -129,7 +132,8 @@ Construct a query that is NOT constrained by filters.
 We will use the results of this query to get the possible values and counts for our filters.
 Below you can see we’re building up a simple query for the jeans content type, gender and collection.
 
-.. code-block:: guess
+.. code-block:: html
+   :force:
 
    <#assign queryStatement = 'content-type:"/component/jeans" ' />
    <#assign queryStatement = queryStatement + 'AND gender.item.key:"' + gender + '" ' />
@@ -141,7 +145,8 @@ Construct a query based on the first but with additional filter constraints
 
 We will use the results of this query to display the results to the user.
 
-.. code-block:: guess
+.. code-block:: html
+   :force:
 
    <#assign filteredQueryStatement = queryStatement />
    <#assign filteredQueryStatement = filteredQueryStatement + ‘AND size.item.value:”‘ + filterSize + ‘” ‘ />
@@ -152,7 +157,8 @@ Execute the unfiltered query
 
 Here you can see we’re declaring the facets we want the counts on.
 
-.. code-block:: guess
+.. code-block:: html
+   :force:
    :linenos:
 
    <#assign query = searchService.createQuery()>
@@ -167,7 +173,8 @@ Execute the filtered query
 
 Here you can see we’re declaring the pagination and sorting options.
 
-.. code-block:: guess
+.. code-block:: html
+   :force:
    :linenos:
 
    <#assign filteredQuery = searchService.createQuery()>
@@ -185,7 +192,8 @@ Assign the results to template variables
 
 Below you can see the how we’re getting the matching jean objects, and number of results returned from the filtered query response.  You can also see how we’re getting the available options and counts from the unfiltered query response.
 
-.. code-block:: guess
+.. code-block:: html
+   :force:
 
    <#assign productsFound = executedFilteredQuery.response.numFound>
    <#assign products = executedFilteredQuery.response.documents />
@@ -201,7 +209,8 @@ Display the products
 
 In the code below, we’re iterating over the available products and simply displaying the details for it.
 
-.. code-block:: guess
+.. code-block:: html
+   :force:
    :linenos:
 
    <#list products as product>
@@ -223,7 +232,8 @@ Construct pagination
 
 Given the number of items found and our productsPerPage value we can determine the number of pages to show to the user.
 
-.. code-block:: guess
+.. code-block:: html
+   :force:
    :linenos:
 
    <div>

--- a/source/site-administrators/engine/engine-mongodb-configuration.rst
+++ b/source/site-administrators/engine/engine-mongodb-configuration.rst
@@ -62,7 +62,7 @@ Use the client from a Groovy script
 
 We can now use the client from a Groovy script.  Here's a simple script that runs a query:
 
-.. code-block:: guess
+.. code-block:: groovy
     :linenos:
 
     def mongo = applicationContext.mongoClient

--- a/source/site-administrators/publishing-and-status.rst
+++ b/source/site-administrators/publishing-and-status.rst
@@ -58,7 +58,7 @@ To publish by commit id, let's use a site created using the Website Editorial bl
 - Edit the Home page (/site/website/index.xm) from the command line or anywhere other than Studio
 - From the command line, commit your changes
 
-  .. code-block:: guess
+  .. code-block:: bash
 
      $ cd crafter-authoring/data/repos/sites/mysite/sandbox/site/website
      $ git add .
@@ -66,7 +66,7 @@ To publish by commit id, let's use a site created using the Website Editorial bl
 
 - Get the commit id after doing the above step
 
-  .. code-block:: guess
+  .. code-block:: bash
 
      $ git log
      commit f47c9a5bae4184e7b5ff2cb03b90b8ff86adec37 (HEAD -> master)

--- a/source/site-administrators/studio/code-editor-configuration.rst
+++ b/source/site-administrators/studio/code-editor-configuration.rst
@@ -80,7 +80,7 @@ Let's take a look at an example of adding the template code example for freemark
 #. Open the ``Sidebar`` and click on |siteConfig| ➜ ``Configuration`` ➜ ``Code Editor Configuration``
 #. Uncomment the snippet ``freemarker-example`` and save your changes
 
-   .. code-block:: guess
+   .. code-block:: xml
       :linenos:
       :emphasize-lines: 8-17
 

--- a/source/system-administrators/activities/authoring/authoring-env-performance-tuning.rst
+++ b/source/system-administrators/activities/authoring/authoring-env-performance-tuning.rst
@@ -60,7 +60,7 @@ Testing Raw Performance
 
 	* Example
 
-      .. code-block:: guess
+      .. code-block:: none
           :linenos:
 
           Timing cached reads:   24486 MB in  1.99 seconds = 12284.28 MB/sec
@@ -72,7 +72,7 @@ Testing Raw Performance
 
 	* Example
 
-      .. code-block:: guess
+      .. code-block:: bash
          :linenos:
 
          $ fio --randrepeat=1 --ioengine=libaio --gtod_reduce=1 --name=test --filename=test --bs=4k --iodepth=64 --size=4G --readwrite=randrw --rwmixread=75
@@ -100,7 +100,7 @@ Testing Raw Performance
 
 	* Example
 
-      .. code-block:: guess
+      .. code-block:: bash
          :linenos:
 
 	     $ ioping -c 10 .
@@ -168,7 +168,7 @@ Crafter CMS includes many subsystems that require additional file-handles be ava
 
 Our limits are:
 
-.. code-block:: guess
+.. code-block:: none
     :linenos:
 
     [Service]

--- a/source/system-administrators/activities/autoclustering-with-studio-galera.rst
+++ b/source/system-administrators/activities/autoclustering-with-studio-galera.rst
@@ -170,7 +170,7 @@ We'll need to start the node we selected for bootstrapping first to start the Pr
 
 To check that your cluster is up, log into the MariaDB monitor and check the cluster size by running the following command:
 
-   .. code-block:: guess
+   .. code-block:: mysql
 
       show status like 'wsrep_cluster_size';
 
@@ -178,7 +178,7 @@ To check that your cluster is up, log into the MariaDB monitor and check the clu
 
 The output should show that there's one cluster:
 
-   .. code-block:: guess
+   .. code-block:: none
 
       MariaDB [crafter]> show status like 'wsrep_cluster_size';
       +---------------------+-------+
@@ -190,7 +190,7 @@ The output should show that there's one cluster:
 
 Once the bootstrap node is up and running, we can start the rest of the nodes by running the startup script ``./gradlew start`` or ``./startup.sh`` depending on if you're using a Crafter CMS build or a bundle.  For our example, we will be starting the node with address ``192.168.1.103``.   Once the second node is up, you can check the cluster size by logging into the MariaDB monitor and verify that your cluster size is now 2
 
-   .. code-block:: guess
+   .. code-block:: none
 
       MariaDB [crafter]> show status like 'wsrep_cluster_size';
       +---------------------+-------+
@@ -236,7 +236,7 @@ Whenever the number of Studios in the cluster is even numbered, the Studio Arbit
 
 #. Run the arbiter ``java -jar studio-arbiter.jar``.  To check that the arbiter is running and part of the cluster, you can check the cluster size by logging into the MariaDB monitor of one of the Studio nodes and verify that your cluster size is now 3
 
-   .. code-block:: guess
+   .. code-block:: none
 
       MariaDB [crafter]> show status like 'wsrep_cluster_size';
       +---------------------+-------+

--- a/source/system-administrators/activities/debugging-search-elasticsearch.rst
+++ b/source/system-administrators/activities/debugging-search-elasticsearch.rst
@@ -86,7 +86,7 @@ Please note the following default behavior of Elasticsearch monitoring the avail
 
 When an index is set as read-only the application log will show messages similar to this one
 
-.. code-block:: guess
+.. code-block:: none
 
    Caused by: ElasticsearchStatusException[Elasticsearch exception [type=cluster_block_exception, reason=blocked by: [FORBIDDEN/12/index read-only / allow delete (api)];]]
 
@@ -94,7 +94,7 @@ When an index is set as read-only the application log will show messages similar
 
 In the Elasticsearch log the following message will be shown:
 
-.. code-block:: guess
+.. code-block:: none
 
    [2019-04-02T16:10:14,520][WARN ][o.e.c.r.a.DiskThresholdMonitor] [uKHC0qA] flood stage disk watermark [95%] exceeded on [uKHC0qAFSrWZguNmsWhFiQ][uKHC0qA][INSTALL_DIR/data/indexes-es/nodes/0] free: 10.5gb[4.5%], all indices on this node will be marked read-only
 

--- a/source/system-administrators/activities/delivery/delivery-env-performance-tuning.rst
+++ b/source/system-administrators/activities/delivery/delivery-env-performance-tuning.rst
@@ -70,7 +70,7 @@ Testing Raw Performance
 
 	* Example
 
-      .. code-block:: guess
+      .. code-block:: bash
           :linenos:
 
           Timing cached reads:   24486 MB in  1.99 seconds = 12284.28 MB/sec
@@ -82,7 +82,7 @@ Testing Raw Performance
 
 	* Example
 
-      .. code-block:: guess
+      .. code-block:: bash
          :linenos:
 
          $ fio --randrepeat=1 --ioengine=libaio --gtod_reduce=1 --name=test --filename=test --bs=4k --iodepth=64 --size=4G --readwrite=randrw --rwmixread=75
@@ -110,7 +110,7 @@ Testing Raw Performance
 
 	* Example
 
-      .. code-block:: guess
+      .. code-block:: bash
          :linenos:
 
 	     $ ioping -c 10 .
@@ -178,7 +178,7 @@ Crafter CMS includes many subsystems that require additional file-handles be ava
 
 Our limits are:
 
-.. code-block:: guess
+.. code-block:: none
     :linenos:
 
     [Service]

--- a/source/system-administrators/activities/delivery/setup-delivery-using-aws-ami.rst
+++ b/source/system-administrators/activities/delivery/setup-delivery-using-aws-ami.rst
@@ -213,7 +213,7 @@ Now that both our public and private keys are installed on their respective serv
 
 SSH on to the delivery server as the ubuntu user and execute the following commands:
 
-.. code-block:: sh
+.. code-block:: bash
     :linenos:
 
     sudo su crafter
@@ -221,7 +221,7 @@ SSH on to the delivery server as the ubuntu user and execute the following comma
 
 It's important that you include the  **-o HostKeyAlgorithms=ssh-rsa** parameter in the initial SSH connection to the authoring server. Crafter expects the fingerprint to be stored in an RSA format. Once you execute the SSH command to log in to the authoring machine from the delivery machine as the crafter user. You will be prompted to verify the auhtenticity of the authoring server.  Type yes to confirm.  After this you will be logged in to the authoring server.  No further action is required. Type exit in to the command line of the authoring server to terminate the SSH session.
 
-.. code-block:: guess
+.. code-block:: text
     :linenos:
 
     The authenticity of host 'ec2-3-93-34-40.compute-1.amazonaws.com (172.31.79.17)' can't be established.
@@ -263,7 +263,7 @@ The SITE_ID parameter can be acquired from the authoring server. Log in to Craft
 
 Successful execution of this command will produce output similar to the following:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     Creating Solr Core...
@@ -273,7 +273,7 @@ Successful execution of this command will produce output similar to the followin
 
 Example:
 
-.. code-block:: sh
+.. code-block:: bash
     :linenos:
 
     init-site.sh -b live editorial ssh://crafter@ec2-3-93-34-40.compute-1.amazonaws.com:/opt/crafter/data/repos/sites/editorial/published
@@ -292,7 +292,7 @@ You can further verify that the deployment is working by watching the logs.  To 
 
 Look for output that is similar to the following:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     2019-04-17 21:39:00.001 INFO 4389 --- [pool-5-thread-1] o.c.d.impl.processors.GitPullProcessor : Cloning Git remote repository ssh://crafter@ec2-3-93-34-40.compute-1.amazonaws.com:/opt/crafter/data/repos/sites/editorial/published into /opt/crafter/data/repos/sites/editorial

--- a/source/system-administrators/activities/delivery/setup-serverless-delivery.rst
+++ b/source/system-administrators/activities/delivery/setup-serverless-delivery.rst
@@ -29,9 +29,9 @@ Since serverless delivery requires a single Elasticsearch endpoint readable by a
 create an AWS Elasticsearch domain for delivery. If you don't want to use an AWS Elasticsearch domain then you should
 create and mantain your own Elasticsearch cluster.
 
-.. important:: Authoring can also use an Elasticsearch domain, but be aware that in a clustered authoring environment
-               each authoring instance requires a separate Elasticsearch instance. If you try to use the same ES domain
-               then you will have multiple preview deployers writing to the same index.
+   .. important:: Authoring can also use an Elasticsearch domain, but be aware that in a clustered authoring environment
+                  each authoring instance requires a separate Elasticsearch instance. If you try to use the same ES domain
+                  then you will have multiple preview deployers writing to the same index.
 
 To create an AWS Elasticsearch domain please do the following:
 
@@ -44,6 +44,8 @@ To create an AWS Elasticsearch domain please do the following:
       :alt: Serverless Site - Elasticsearch Deployment Type
       :align: center
 
+   |
+
 #. On the next screen, enter the domain name. Leave the defaults on the rest of the settings or change as needed per
    your environment requirements, then click on ``Next``.
 #. On ``Network Configuration``, we recommend you pick the VPC where your delivery nodes reside. If they're not running 
@@ -53,12 +55,16 @@ To create an AWS Elasticsearch domain please do the following:
       :alt: Serverless Site - Elasticsearch Network Access
       :align: center
 
+   |
+
 #. Select the ``Access Policy`` that fits your Crafter environment, and click on ``Next`` (if on the same VPC as 
    delivery, we recommend ``Do not require signing request with IAM credential``).
 
    .. image:: /_static/images/system-admin/serverless/es-access-policy.png
       :alt: Serverless Site - Elasticsearch Access Policy
       :align: center
+
+   |
 
 #. Review the settings and click on ``Confirm``.
 #. Wait for a few minutes until the domain is ready. Copy the ``Endpoint``. You'll need this URL later to configure
@@ -67,6 +73,8 @@ To create an AWS Elasticsearch domain please do the following:
    .. image:: /_static/images/system-admin/serverless/es-endpoint.png
       :alt: Serverless Site - Elasticsearch Endpoint
       :align: center
+
+   |
 
 --------------------------------------------------
 Step 2: Configure the Delivery for Serverless Mode
@@ -88,6 +96,8 @@ Step 2: Configure the Delivery for Serverless Mode
 
       </beans>
 
+   |
+
 #. Edit the properties override file to point Engine to consume the site content from S3
    (``DELIVERY_INSTALL_DIR/bin/apache-tomcat/shared/classes/crafter/engine/extension/server-config.properties``). The
    properties you need to update are the following:
@@ -101,6 +111,7 @@ Step 2: Configure the Delivery for Serverless Mode
    (which is the most common use case), is the following (values in ``X`` are not displayed since they're sensitive):
 
    .. code-block:: properties
+      :force:
 
       # Content root folder when using S3 store. Format is s3://<BUCKET_NAME>/<SITES_ROOT>/{siteName}
       crafter.engine.site.default.rootFolder.path=s3://serverless-test-site-{siteName}/{siteName}
@@ -113,6 +124,8 @@ Step 2: Configure the Delivery for Serverless Mode
       crafter.engine.s3.accessKey=XXXXXXXXXX
       # AWS secret key
       crafter.engine.s3.secretKey=XXXXXXXXXXXXXXXXXXXX
+
+   |
 
    As you can see, the bucket name portion of the root folder S3 URL contains a prefix and then the site name. This
    prefix is mentioned also as a "namespace" later on in the Studio serverless configuration.
@@ -127,6 +140,8 @@ Step 2: Configure the Delivery for Serverless Mode
    .. code-block:: bash
 
       export ES_URL=https://vpc-serverless-test-jpwyav2k43bb4xebdrzldjncbq.us-east-1.es.amazonaws.com
+
+   |
 
 #. Make sure that the you have an application load balancer (ALB) fronting the Delivery Engine instances and that it's 
    accessible by AWS CloudFront.
@@ -152,7 +167,9 @@ notice:
     
     studio.serverless.delivery.deployer.target.template.params:
       # The delivery Elasticsearch endpoint (optional is authoring is using the same one, specified in the ES_URL env variable)
-      elastic_search_url: https://vpc-serverless-test-jpwyav2k43bb4xebdrzldjncbq.us-east-1.es.amazonaws.com    
+      elastic_search_url: https://vpc-serverless-test-jpwyav2k43bb4xebdrzldjncbq.us-east-1.es.amazonaws.com
+
+  |
 
 - When using the ``aws-cloudformed-s3`` target template (the default one), the Deployer creates first an AWS 
   CloudFormation stack with an S3 bucket where the site content will be uploaded and a CloudFront that will serve 
@@ -177,6 +194,8 @@ notice:
            # AWS secret key (optional if specified through default AWS chain)
            default_secret_key: XXXXXXXXXXXXXXXXXXXX
 
+    |
+
   - In ``aws.cloudformation.access_key`` and ``aws.cloudformation.secret_key`` properties under 
     ``studio.serverless.delivery.deployer.target.template.params``, when specific CloudFormation credentials are needed:
 
@@ -190,6 +209,8 @@ notice:
              access_key: XXXXXXXXXX
              # AWS secret key (optional if aws.secretKey is specified)
              secret_key: XXXXXXXXXXXXXXXXXXXX
+
+    |
 
 - By default, the CloudFront created by Deployer will have a ``*.cloudfront.net`` domain name. To have CloudFront use 
   additional domain name(s) please specify the AWS ARN of the domain SSL certificate (``cloudfrontCertificateArn``) and 
@@ -205,6 +226,8 @@ notice:
            cloudfrontCertificateArn: arn:aws:acm:...
            # The alternate domains names (besides *.cloudfront.net) for the CloudFront CDN (optional when target template is aws-cloudformed-s3)
            alternateCloudFrontDomainNames: myawesomesite.com,www.myawesomesite.com
+
+  |
 
 An example of serverless deployment configuration where there's a single authoring instance and no specific domain
 name requirements is the following:
@@ -247,6 +270,7 @@ name requirements is the following:
           # The domain name of the serverless delivery LB (required when target template is aws-cloudformed-s3)
           deliveryLBDomainName: serverless-test-lb-1780491458.us-east-1.elb.amazonaws.com
 
+|
 
 ----------------------------------------------------
 Step 4: Create the Site in the Authoring Environment
@@ -263,6 +287,8 @@ Step 4: Create the Site in the Authoring Environment
    .. image:: /_static/images/system-admin/serverless/cloudformation.png
       :alt: Serverless Site - CloudFormation
       :align: center
+
+   |
 
 #. Wait at least 2 minutes for the Crafter Deployer to finish uploading the files and for the delivery Crafter Engine
    to warm up the new site in cache.
@@ -318,6 +344,8 @@ Step 4: Create the Site in the Authoring Environment
       2019-12-20 20:49:15.882  INFO 18846 --- [deployment-8] org.craftercms.deployer.impl.TargetImpl  : ============================================================
       2019-12-20 20:49:15.882  INFO 18846 --- [deployment-8] org.craftercms.deployer.impl.TargetImpl  : Deployment for editorial-serverless-delivery finished in 15.878 secs
       2019-12-20 20:49:15.882  INFO 18846 --- [deployment-8] org.craftercms.deployer.impl.TargetImpl  : ============================================================
+
+   |
 
    .. code-block:: none
       :caption: engine.log
@@ -377,6 +405,8 @@ Step 4: Create the Site in the Authoring Environment
       [INFO] 2019-12-20T20:50:04,393 [pool-3-thread-10] [] [context.SiteContextManager] | ================================================== 
       [INFO] 2019-12-20T20:50:04,393 [pool-3-thread-10] [] [context.SiteContextManager] | </Creating site context: editorial> 
       [INFO] 2019-12-20T20:50:04,393 [pool-3-thread-10] [] [context.SiteContextManager] | ==================================================   
+
+   |
 
 ------------------------------
 Step 5: Test the Delivery Site

--- a/source/system-administrators/activities/delivery/setup-site-for-delivery.rst
+++ b/source/system-administrators/activities/delivery/setup-site-for-delivery.rst
@@ -21,7 +21,8 @@ In the ``bin`` folder in your Crafter CMS delivery environment, we will use the 
 From your command line, navigate to your ``{Crafter-CMS-delivery-environment-directory}/bin/`` , and execute the init-site script. The following output of ``init-site.sh -h``
 explains how to use the script:
 
-  .. code-block:: guess
+  .. code-block:: bash
+    :force:
 
     usage: init-site [options] [site] [repo-path]
      -a,--notification-addresses <addresses>   A comma-separated list of email
@@ -46,6 +47,7 @@ explains how to use the script:
      -u,--username <username>                  The username for the remote Git
                                                repo, when using basic
                                                authentication
+
     EXAMPLES:
      Init a site from the default repo path (../../crafter-authoring/data/repos/sites/{sitename}/published)
          init-site mysite
@@ -79,7 +81,7 @@ Example #2: ``ssh://jdoe@server2.example.com:63022/path/to/repo``
 If you are just working on another directory on disk for your delivery, you can just use the filesystem.  When your repository is local, make sure to use the absolute path.
 Here is an example site's published repo Git url when using a local repository:
 
-  .. code-block:: guess
+  .. code-block:: bash
 
       /opt/crafter/authoring/data/repos/sites/mysite/published
 

--- a/source/system-administrators/activities/language-support/add-new-language.rst
+++ b/source/system-administrators/activities/language-support/add-new-language.rst
@@ -42,7 +42,8 @@ Let's begin adding the language ``Japanese`` to Crafter Studio:
 * Copy the contents from one of the existing json files, ``locale-en.json`` and paste it into the new file, ``locale-ja.json``.
 * Start translating the content in your ``locale-ja.json`` file, then save your changes
 
-    .. code-block:: guess
+    .. code-block:: json
+       :force:
        :caption: *studio-ui/static-assets/scripts/resources/locale-ja.json*
        :linenos:
 
@@ -147,7 +148,8 @@ Remember to change the language code in the all the ``registerBundle`` calls in 
 
 * After generating the ``ja.json`` locale file from above, open the file in your ``studio-ui`` code by navigating to ``/studio-ui/ui/app/src/translations/locales/``, then open the ``ja.json`` file and start translating the content
 
-  .. code-block:: guess
+  .. code-block:: json
+     :force:
 
      {
        "blueprint.by": "バイ",
@@ -168,7 +170,8 @@ Remember to change the language code in the all the ``registerBundle`` calls in 
 
 * Add the new language imports ``<script src="/studio/static-assets/components/cstudio-common/resources/ja/base.js?version=${UIBuildId!.now?string('Mddyyyy')}"></script>`` into the files listed above:
 
-  .. code-block:: guess
+  .. code-block:: html
+     :force:
      :linenos:
      :emphasize-lines: 6
      :caption: *studio-ui/templates/web/preview.ftl*

--- a/source/system-administrators/activities/reindexing-content-in-prod.rst
+++ b/source/system-administrators/activities/reindexing-content-in-prod.rst
@@ -82,7 +82,7 @@ You will see indexing activity in the deployment log located in ``INSTALL_DIRECT
 Indexing activity time is dependent on the amount of content which must be re-processed. When the deployment/indexing 
 finishes you should see something like the following in the log:
 
-.. code-block:: guess
+.. code-block:: none
 
   2017-07-25 16:52:03.762  INFO 21896 --- [pool-2-thread-1] org.craftercms.deployer.impl.TargetImpl  : ------------------------------------------------------------
   2017-07-25 16:52:03.763  INFO 21896 --- [pool-2-thread-1] org.craftercms.deployer.impl.TargetImpl  : Deployment for SITE_NAME_v2 finished in 2.359 secs
@@ -187,7 +187,7 @@ You will see indexing activity in the deployment log located in ``INSTALL_DIRECT
 Indexing activity time is dependent on the amount of content which must be re-processed. When the deployment/indexing 
 finishes you should see something like the following in the log:
 
-.. code-block:: guess
+.. code-block:: none
 
   2017-07-25 16:52:03.762  INFO 21896 --- [pool-2-thread-1] org.craftercms.deployer.impl.TargetImpl  : ------------------------------------------------------------
   2017-07-25 16:52:03.763  INFO 21896 --- [pool-2-thread-1] org.craftercms.deployer.impl.TargetImpl  : Deployment for editorial-tmp-prod finished in 2.359 secs

--- a/source/system-administrators/activities/reindexing-content.rst
+++ b/source/system-administrators/activities/reindexing-content.rst
@@ -159,7 +159,7 @@ To start reindexing/reprocessing, send the following CURL command:
 
 After sending the CURL command, you will get a response like this:
 
-.. code-block:: guess
+.. code-block:: json
 
    {"message":"OK"}
 
@@ -172,7 +172,7 @@ Step 3: Wait for indexing
 You will see indexing activity in the deployment log located in ``INSTALL_DIRECTORY/logs/deployer/crafter-deployer.out``. Indexing activity time is dependent on the amount of content which must be re-processed. When the
 deployment/indexing finishes you should see something like the following in the log:
 
-.. code-block:: guess
+.. code-block:: none
 
 	2017-07-25 16:52:03.762  INFO 21896 --- [pool-2-thread-1] org.craftercms.deployer.impl.TargetImpl  : ------------------------------------------------------------
 	2017-07-25 16:52:03.763  INFO 21896 --- [pool-2-thread-1] org.craftercms.deployer.impl.TargetImpl  : Deployment for editorial-preview finished in 2.359 secs

--- a/source/system-administrators/activities/security/configure-headers-based-auth.rst
+++ b/source/system-administrators/activities/security/configure-headers-based-auth.rst
@@ -185,7 +185,7 @@ When setting up the ADFS connection with Crafter CMS, the following custom rules
 
 The first rule extracts all of the groups out and moves them into a temp store:
 
-.. code-block:: guess
+.. code-block:: none
 
     c:[Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname", Issuer == "AD AUTHORITY"]
     => add(store = "Active Directory", types = ("http://schemas.xmlsoap.org/claims/Group"), query = ";tokenGroups;{0}", param = c.Value);
@@ -195,7 +195,7 @@ The first rule extracts all of the groups out and moves them into a temp store:
 
 The second rule filters down to the regex of ``.myproject.`` or basically anything that includes ``myproject`` in the group name and then prepends the actual value with "myproject-site":
 
-.. code-block:: guess
+.. code-block:: none
 
     c:[Type == "http://schemas.xmlsoap.org/claims/Group", Value =~ ".*myproject.*"]
     => issue(Type = "groups", Value = "myproject-site," + c.Value, Issuer = c.Issuer);
@@ -206,7 +206,7 @@ After setting up the custom rules above, we need to setup 2 more rules for SAML 
 
 Setup the SAML Map to AD Properties:
 
-.. code-block:: guess
+.. code-block:: none
 
     c:[Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname", Issuer == "AD AUTHORITY"]
     => issue(store = "Active Directory", types = ("email", "firstname", "lastname", "username"), query = ";mail,givenName,sn,sAMAccountName;{0}", param = c.Value);
@@ -215,7 +215,7 @@ Setup the SAML Map to AD Properties:
 
 Configure Claim Rule Transform ("Transform an incoming claim") that maps the desired Claim data into SAML data element, nameid:
 
-.. code-block:: guess
+.. code-block:: none
 
     c:[Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]
     => issue(Type = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier", Issuer = c.Issuer, OriginalIssuer = c.OriginalIssuer, Value = c.Value, ValueType = c.ValueType, Properties["http://schemas.xmlsoap.org/ws/2005/05/identity/claimproperties/format"] = "urn:oasis:names:tc:SAML:2.0:nameid-format:transient");

--- a/source/system-administrators/activities/security/configure-ldap.rst
+++ b/source/system-administrators/activities/security/configure-ldap.rst
@@ -60,7 +60,7 @@ created in the database with the imported LDAP attributes, and finally added to 
 
 Also, please note that Studio needs all the attributes listed in the config to be present in the LDAP user's attributes, otherwise, Studio is not able to authenticate the user.  When an attribute is missing, an error message will be displayed in the login screen: ``A system error has occurred.  Please wait a few minutes or contact an administrator``.  Please look at the tomcat log to check which attribute was not found.  Here's an example log:
 
-.. code-block:: guess
+.. code-block:: none
 
     [WARN] 2017-10-11 12:42:57,487 [http-nio-8080-exec-2] [security.DbWithLdapExtensionSecurityProvider] | No LDAP attribute crafterGroup found for username cbrunato
 

--- a/source/system-administrators/commons/encryption-tool.rst
+++ b/source/system-administrators/commons/encryption-tool.rst
@@ -15,28 +15,28 @@ sub-module, where you should find the JAR with the ``-enctool`` suffix. Then you
 
 - **Encode text in Base 64:** ``java -jar {JARNAME} -e64 CLEAR_TEXT``
 
-	.. code-block:: guess
+	.. code-block:: bash
 
 		java -jar crafter-commons-utilities-3.0.1-enctool.jar -e64 KniOddyi
 		Encoded text in Base 64: S25pT2RkeWk=
 
 - **Decode Base 64 text:** ``java -jar {JARNAME} -d64 BASE64_TEXT``
 
-	.. code-block:: guess
+	.. code-block:: bash
 
 		java -jar crafter-commons-utilities-3.0.1-enctool.jar -d64 S25pT2RkeWk=
 		Decoded Base 64 text: KniOddyi
 
 - **Encrypt text:** ``java -jar {JARNAME} -e CLEAR_TEXT -p PASSWORD -s BASE64_SALT``
 
-	.. code-block:: guess
+	.. code-block:: bash
 
 		java -jar crafter-commons-utilities-3.0.1-enctool.jar -e c852cb30cda311e488300800200c9a66 -p klanFogyetkonjo -s S25pT2RkeWk=
 		Cipher text (in Base 64): VkHxBsaSZ9DXrXk52uK9And+CEZlqiy7Wb23GxBFOSXD6KBOCh1ojp8fUw7w11IxpxBipiI4HsSg3cdl9TgTQg==
 
 - **Decrypt text:** ``java -jar {JARNAME} -d CIPHER_TEXT -p PASSWORD -s BASE64_SALT``
 
-	.. code-block:: guess
+	.. code-block:: bash
 
 		java -jar crafter-commons-utilities-3.0.1-enctool.jar -d VkHxBsaSZ9DXrXk52uK9And+CEZlqiy7Wb23GxBFOSXD6KBOCh1ojp8fUw7w11IxpxBipiI4HsSg3cdl9TgTQg== -p klanFogyetkonjo -s S25pT2RkeWk=
 		Clear text: c852cb30cda311e488300800200c9a66

--- a/source/system-administrators/deployer/admin-guide.rst
+++ b/source/system-administrators/deployer/admin-guide.rst
@@ -210,7 +210,7 @@ By default the processed commits are stored in a folder (``CRAFTER_HOME/data/dep
 as an individual file for each target (for example ``editorial-preview.commit``). Each file contains
 only the commit id that will be used to track the changes during deployments:
 
-.. code-block:: guess
+.. code-block:: none
   :caption: Example of a processed commit file
   :linenos:
   

--- a/source/system-administrators/profile/index.rst
+++ b/source/system-administrators/profile/index.rst
@@ -245,7 +245,7 @@ templates and configure Crafter Profile to use them following this steps:
 
 The templates will have available the ``verificationLink`` variable.
 
-.. code-block:: guess
+.. code-block:: html
   :caption: Example Email Template
 
   Click on the link below to verify your Crafter Profile account.

--- a/source/system-administrators/social/admin/guides/preferences.rst
+++ b/source/system-administrators/social/admin/guides/preferences.rst
@@ -42,7 +42,8 @@ This section includes Context specific templates for all supported event notific
 
 All email templates need to be valid HTML pages and can use any feature from Freemarker.
 
-.. code-block:: guess
+.. code-block:: html
+  :force:
   :caption: Example Email Template
   :linenos:
 

--- a/source/system-administrators/social/admin/index.rst
+++ b/source/system-administrators/social/admin/index.rst
@@ -45,7 +45,7 @@ properties file placed in the following location:
 
 You can change any of the default configuration, some of the more relevant properties are:
 
-.. code-block:: guess
+.. code-block:: properties
 
   crafter.social.app.rootUrl=
   crafter.social.app.name=crafter-social

--- a/source/system-administrators/social/index.rst
+++ b/source/system-administrators/social/index.rst
@@ -255,7 +255,7 @@ Enable ClamAV Virus Scanner
 1. Install ClamAV
 2. Edit the ClamAV configuration file to include the following properties:
 
-.. code-block:: guess
+.. code-block:: text
   :caption: clamd.conf
   :linenos:
 

--- a/source/system-administrators/studio/debugging-upgrade-issues.rst
+++ b/source/system-administrators/studio/debugging-upgrade-issues.rst
@@ -15,7 +15,7 @@ Failure Executing a Statement
 -----------------------------
 Let's take a look at an example log:
 
-.. code-block:: guess
+.. code-block:: bash
     :caption: Failed statement during upgrade
     :linenos:
 
@@ -48,7 +48,7 @@ Upgrade Not Supported
 ---------------------
 When the system is in an undefined state between two versions, you may see the following message in the logs:
 
-.. code-block:: guess
+.. code-block:: text
     :caption: System in an undefined state between two versions
 
     Caused by: org.craftercms.studio.api.v2.exception.UpgradeNotSupportedException: The current database version can't be upgraded

--- a/source/system-administrators/studio/studio-configuration-overrides.rst
+++ b/source/system-administrators/studio/studio-configuration-overrides.rst
@@ -107,7 +107,7 @@ Database Configuration
 
 The following section of Studio's configuration overrides allows you to setup the database url, port number, connection string to initialize the database and path
 
-.. code-block:: guess
+.. code-block:: yaml
    :caption: shared/classes/crafter/studio/extension/studio-config-override.yaml
    :linenos:
 

--- a/source/system-administrators/upgrade/index.rst
+++ b/source/system-administrators/upgrade/index.rst
@@ -85,7 +85,8 @@ After the ``upgrade-target`` script is done with the upgrade, change to your tar
 
 Below is a sample output when you start the upgrade-target script:
 
-    .. code-block:: guess
+    .. code-block:: bash
+        :force:
 
         > Backup the data folder before upgrade? [(Y)es/(N)o]:
 

--- a/source/system-administrators/upgrade/upgrading-to-craftercms-3-1-3.rst
+++ b/source/system-administrators/upgrade/upgrading-to-craftercms-3-1-3.rst
@@ -23,7 +23,7 @@ To upgrade 3.1.0 Docker/Kuber deployments to 3.1.3:
 #. Change the image version to 3.1.3 and restart containers.
 #. Wait for the containers to come up, the ``authoring_tomcat`` log should show some DB errors.
 
-   .. code-block:: guess
+   .. code-block:: bash
 
       tomcat_1         | Caused by: org.craftercms.studio.api.v2.exception.UpgradeException: Error executing sql script upgrade-3.1.0.34-to-3.1.0.35.sql
       ...


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
Update code-block guess lexers for updated sphinx-doc version.

After updating sphinx-doc (v2.3.1), there were updates to the lexer where `guess` is not supported anymore.  

The option `:force:` was also added, to ignore minor errors on highlighting, for code-blocks listing ftls for example (no lexer for ftl, but can use `html` to have highlights on html part), or using ellipses inside code-block  to represent repetitive values, etc.

https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html

Please note too that there will be a warning when building:
```
RemovedInSphinx30Warning: To modify script_files in the theme is deprecated. Please insert a <script> tag directly in your theme instead.
```
Ticket https://github.com/craftercms/craftercms/issues/3786 filed for above warning