### PR TITLE
Update code-block guess lexers for updated sphinx-doc version for 3.0

### DIFF
--- a/source/developers/content-modeling.rst
+++ b/source/developers/content-modeling.rst
@@ -613,7 +613,8 @@ View templates control how the model is rendered as HTML. Crafter uses `FreeMark
 
 An example view template
 
-.. code-block:: guess
+.. code-block:: html
+   :force:
    :linenos:
 
 	<#import "/templates/system/common/cstudio-support.ftl" as studio />

--- a/source/developers/content-type-component.rst
+++ b/source/developers/content-type-component.rst
@@ -141,7 +141,7 @@ A dialog will then open where you can start entering your script.  Let's take a 
 
 |
 
-.. code-block:: guess
+.. code-block:: groovy
     :linenos:
 
         import org.craftercms.sites.editorial.SearchHelper

--- a/source/developers/content-type-page.rst
+++ b/source/developers/content-type-page.rst
@@ -149,13 +149,15 @@ We will now start filling in the template of how we want the content captured in
 	:alt: Template FTL
 	:align: center
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
     :caption: Render header
 
     <!-- Header -->
         <@renderComponent component = contentModel.header.item />
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
     :caption: Render content section
     :linenos:
 
@@ -205,7 +207,7 @@ We can now start adding the script to get a list of articles depending on the ac
 	:alt: Template Controller Script
 	:align: center
 
-.. code-block:: guess
+.. code-block:: groovy
     :linenos:
 
     import org.craftercms.sites.editorial.SearchHelper
@@ -227,7 +229,8 @@ Now that we have our controller, we just need to add code to the freemarker temp
 	:alt: Template Modify FTL to Display Controller Script Output
 	:align: center
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
     :linenos:
 
     <section>

--- a/source/developers/cook-books/aws/use-s3-to-store-assets.rst
+++ b/source/developers/cook-books/aws/use-s3-to-store-assets.rst
@@ -194,7 +194,8 @@ Now that we have the Groovy code to generate the URLs, we need the Freemarker co
 the ``Templates`` > ``web`` > ``pages`` > ``article.ftl``, add the following lines after the
 ``<#list contentModel.sections.item as item>...</#list>`` lines:
 
-.. code-block:: guess
+.. code-block:: html
+  :force:
 
   <#if attachments??>
     <h2>Attachments</h2>

--- a/source/developers/cook-books/box/use-box-to-store-assets.rst
+++ b/source/developers/cook-books/box/use-box-to-store-assets.rst
@@ -197,7 +197,8 @@ Step 6: Add Freemarker code to render the URLs
 
 Now that we have the Groovy code to generate the URLs, we need the Freemarker code that will render the URLs. In the Templates > web > pages > article.ftl, add the following lines after the ``<#list contentModel.sections.item as item>...</#list>`` lines:
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
     :linenos:
 
     <#if attachments??>

--- a/source/developers/cook-books/how-tos/components-in-rte.rst
+++ b/source/developers/cook-books/how-tos/components-in-rte.rst
@@ -26,7 +26,8 @@ Basic Setup and Configuration
 
 #. Create the component template.  From the content model definition, go to the **Properties Explorer** panel and select the **Display Template** field.  Click on the pencil which will open a **Create Template** dialog.  Provide a filename for the template then it will open a blank template that we can then fill in with the following:
 
-   .. code-block:: guess
+   .. code-block:: html
+      :force:
 
       <h1>${model.greetingText}</h1>
 

--- a/source/developers/cook-books/how-tos/setting-up-an-ldap-server-for-dev.rst
+++ b/source/developers/cook-books/how-tos/setting-up-an-ldap-server-for-dev.rst
@@ -105,7 +105,7 @@ The server we setup earlier does not have any data yet.  We will now load some d
 
 An empty file in the middle of your ApacheDS will appear.  This is the LDIF editor.  We will now enter some data into it to create users that Crafter Studio can authenticate through the LDAP Server we just setup.  We will add three users, each belonging to a different group for the site **myawesomesite** in Crafter Studio.  Please make sure that the attributes listed in the Crafter Studio LDAP configuration is configured in the LDAP server for each user.  Copy and paste the data listed below into the LDIF editor.  Make sure that there is an empty line after the last entry.
 
-.. code-block:: guess
+.. code-block:: text
     :linenos:
 
     dn: dc=example,dc=com
@@ -179,7 +179,7 @@ An empty file in the middle of your ApacheDS will appear.  This is the LDIF edit
 
 Please note that a user can belong to multiple groups and sites.  To add another siteId or groupName value in the ldif file, just add another line specifying the attribute and the value. Notice the multiple values for the attributes **ou** (groupName) and **o** (siteId)
 
-.. code-block:: guess
+.. code-block:: text
     :linenos:
 
     dn: cn=John Wick,ou=Users,dc=example,dc=com

--- a/source/developers/cook-books/how-tos/working-with-crafter-studios-api.rst
+++ b/source/developers/cook-books/how-tos/working-with-crafter-studios-api.rst
@@ -28,7 +28,7 @@ Let's begin:
    We’ll use the authenticate API
    http://docs.craftercms.org/en/3.0/developers/projects/studio/api/security/login.html
 
-   .. code-block:: guess
+   .. code-block:: bash
 
        curl -d '{"username":"admin","password":"admin"}' --cookie "XSRF-TOKEN=A_VALUE" --header "X-XSRF-TOKEN:A_VALUE" --header "Content-Type: application/json" -v -X POST http://localhost:8080/studio/api/1/services/api/1/security/login.json
 
@@ -40,7 +40,7 @@ Let's begin:
 
    After issuing the CURL command you will get back a response:
 
-   .. code-block:: guess
+   .. code-block:: bash
       :linenos:
 
            * Trying ::1...
@@ -78,7 +78,7 @@ Let's begin:
    We'll get a list of sites the user is authorized to work with
    http://docs.craftercms.org/en/3.0/developers/projects/studio/api/site/get-sites-per-user.html
 
-   .. code-block:: guess
+   .. code-block:: bash
 
       curl --cookie "XSRF-TOKEN=A_VALUE;JSESSIONID=2E114725C82F3EE44ADC04B578A3BE8F" -H "X-XSRF-TOKEN:A_VALUE"  -X GET http://localhost:8080/studio/api/1/services/api/1/site/get-per-user.json?username=admin
 
@@ -87,7 +87,7 @@ Let's begin:
    Note the CURL command contains your session ID and XSRF tokens.
    After issuing the CURL command you will get a response that contains sites your user has access to:
 
-   .. code-block:: guess
+   .. code-block:: bash
 
       {"sites":[{"id":9,"siteId":"ar","name":"ar","description":"","status":null,"liveUrl":null,"lastCommitId":"951004363449cc83209f307b1e9f110dab37fed7","publishingEnabled":1,"publishingStatusMessage":"idle|Idle","lastVerifiedGitlogCommitId":null},{"id":5,"siteId":"diiot","name":"diiot","description":"","status":null,"liveUrl":null,"lastCommitId":"92d543eaa164b1ebfbdd6ce538ae028d4d6421b7","publishingEnabled":0,"publishingStatusMessage":"idle|Idle","lastVerifiedGitlogCommitId":"92d543eaa164b1ebfbdd6ce538ae028d4d6421b7"},{"id":10,"siteId":"editorialcom","name":"editorialcom","description":"","status":null,"liveUrl":null,"lastCommitId":"503d922f226e8ab821073e23ef5a229f907212a0","publishingEnabled":1,"publishingStatusMessage":"","lastVerifiedGitlogCommitId":"503d922f226e8ab821073e23ef5a229f907212a0"},{"id":3,"siteId":"flow","name":"flow","description":"","status":null,"liveUrl":null,"lastCommitId":"21923775c3a1fc778a364d47884b9ee2bb4928a5","publishingEnabled":1,"publishingStatusMessage":"idle|Idle","lastVerifiedGitlogCommitId":"21923775c3a1fc778a364d47884b9ee2bb4928a5"},{"id":8,"siteId":"vr","name":"vr","description":"","status":null,"liveUrl":null,"lastCommitId":"c67fd9dd25d1aa59ff13e3fda2a4387be50dfc69","publishingEnabled":1,"publishingStatusMessage":"idle|Idle","lastVerifiedGitlogCommitId":null}],"total":6}
 
@@ -100,7 +100,7 @@ Let's begin:
    We'll now write content to the Editorial com Project
    http://docs.craftercms.org/en/3.0/developers/projects/studio/api/content/write-content.html
 
-   .. code-block:: guess
+   .. code-block:: bash
 
       curl -d "<page><content-type>/page/category-landing</content-type><display-template>/templates/web/pages/category-landing.ftl</display-template><merge-strategy>inherit-levels</merge-strategy><file-name>index.xml</file-name><folder-name>test3</folder-name><internal-name>test3</internal-name><disabled >false</disabled></page>" --cookie "XSRF-TOKEN=A_VALUE;JSESSIONID=2E114725C82F3EE44ADC04B578A3BE8F" -H "X-XSRF-TOKEN:A_VALUE"  -X POST "http://localhost:8080/studio/api/1/services/api/1/content/write-content.json?site=editorialcom&phase=onSave&path=/site/website/test3/index.xml&fileName=index.xml&user=admin&contentType=/page/category-landing&unlock=true"
 

--- a/source/developers/cook-books/how-tos/working-with-dates-freemarker.rst
+++ b/source/developers/cook-books/how-tos/working-with-dates-freemarker.rst
@@ -26,7 +26,8 @@ Using Freemarker Date Built-ins
 -------------------------------
 To display just the date, no time, on when the article was created, we can access the contentModel variable ``date_dt``, and add to the template under the author:
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
 
     <h1>${contentModel.subject!""}</h1>
     <h2>by ${contentModel.author!""}</h2>
@@ -40,42 +41,45 @@ Which will display the following::
 
 To display the date and time:
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
 
     <h3>${contentModel.date_dt?datetime}</h3}
 
 
 Which will output this:
 
-.. code-block:: guess
+.. code-block:: text
 
     2016-12-28T05:00:00.000Z
 
 
 To display the date and time with some formatting:
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
 
     <h3>${contentModel.date_dt?datetime?string["EEEE, MMMM dd, yyyy, hh:mm a '('zzz')'"]}</h3>
 
 
 Which will output this:
 
-.. code-block:: guess
+.. code-block:: text
 
     Wednesday, December 28, 2016, 05:00 AM (UTC)
 
 
 As you can see from the last two examples, the date and time the article was created is in UTC.  If we want to display it in the time zone specified in the `Engine Site Configuration` file, do the following:
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
 
     <h3>${contentModel.date_dt?datetime?iso(siteConfig.getString("timeZone"))}</h3>
 
 
 Which will output this:
 
-.. code-block:: guess
+.. code-block:: text
 
      2016-12-27T21:00:00-08:00
 
@@ -86,28 +90,30 @@ Using the Freemarker time_zone and date_time Setting
 
 If we want to set the time zone used by the template to display dates, Freemarker provides a ``time_zone`` setting.  Once you set the time zone, all date displays will be in the time zone specified.  Let's set all the date and time display in the time zone we specified in the `Engine Site Config` file.
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
 
     <#setting time_zone = siteConfig.getString("timeZone")>
     <h3>${contentModel.date_dt?datetime}</h3>
 
 Which will display:
 
-.. code-block:: guess
+.. code-block:: text
 
     2016-12-27T21:00:00.000-08
 
 
 If we want all date and time displays to follow a certain format, we can use the ``datetime_format`` setting.
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
 
     <#setting datetime_format = "EEEE, MMMM dd, yyyy, hh:mm a '('zzz')'">
 
 
 Which will display the same time as the previous example, but in the format specified:
 
-.. code-block:: guess
+.. code-block:: text
 
     Tuesday, December 27, 2016, 09:00 PM (PST)
 

--- a/source/developers/cook-books/how-tos/working-with-dates-groovy.rst
+++ b/source/developers/cook-books/how-tos/working-with-dates-groovy.rst
@@ -31,7 +31,7 @@ To format the date to a certain format pattern, which we then pass to a template
 
 Which will output this:
 
-.. code-block:: guess
+.. code-block:: text
 
     Tuesday, December 27, 2016, 09:00 PM (PST)
 
@@ -45,7 +45,7 @@ To format the date for a certain format pattern and time zone, do the following:
 
 Which will output this:
 
-.. code-block:: guess
+.. code-block:: text
 
     Wednesday, December 28, 2016, 12:00 AM (EST)
 
@@ -57,7 +57,7 @@ Let's show another example of formatting the date for a certain format pattern a
 
 Which will output this:
 
-.. code-block:: guess
+.. code-block:: text
 
     Tue, December 27, 2016, 09:00 PM (PST)
 
@@ -78,7 +78,7 @@ To convert a date string into a date object (so you can perform date arithmetic,
 
 Which will output this for ``nowDate``:
 
-.. code-block:: guess
+.. code-block:: text
 
     Thu Oct 26 23:45:23 PDT 2017
 
@@ -100,7 +100,7 @@ Say, we want to find the date object 10 days after the date in our example above
 
 Both ``addDate`` and ``addDate2``, will output:
 
-.. code-block:: guess
+.. code-block:: text
 
     Sun Nov 05 23:45:23 PST 2017
 
@@ -113,7 +113,7 @@ Now, if we want to find out the date object 30 days before the date in our examp
 
 Both ``subDate`` and ``subDate2`` will output:
 
-.. code-block:: guess
+.. code-block:: text
 
     Tue Sep 26 23:45:23 PDT 2017
 

--- a/source/developers/cook-books/how-tos/working-with-filters.rst
+++ b/source/developers/cook-books/how-tos/working-with-filters.rst
@@ -18,7 +18,7 @@ Let’s start simple. We’ll create a controller that prints a message before p
 
 Here’s the code:
 
-    .. code-block:: guess
+    .. code-block:: js
 
        logger.info("Handling the request")
        filterChain.doFilter(request, response)

--- a/source/developers/developer-workflow/implementation-devops-workflow.rst
+++ b/source/developers/developer-workflow/implementation-devops-workflow.rst
@@ -50,7 +50,7 @@ To create a branch you use the following GitFlow command:
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(master) git flow init
@@ -87,7 +87,7 @@ To create a branch you use the following GitFlow command:
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(master) git flow feature start MYFEATURE
@@ -115,7 +115,7 @@ To publish a branch you use the following GitFlow command
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(feature/MYFEATURE) git flow feature publish MYFEATURE
@@ -166,7 +166,7 @@ To get branch you use the following GitFlow command
 
 Example:
 
-.. code-block:: guess
+.. code-block:: text
     :linenos:
 
     ➜  sandbox git:(feature/MYFEATURE) git flow feature pull origin MYFEATURE
@@ -211,7 +211,7 @@ To push your updates to the Remote Code Repository you use the following Git com
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(feature/MYFEATURE) git push origin feature/MYFEATURE
@@ -279,7 +279,7 @@ To complete the squash of multiple commits into a single commit use the followin
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(feature/MYFEATURE) ✗ git commit -m "Combining all MYFEATURE Commits in to a single Commit ID"
@@ -298,7 +298,7 @@ To rebase the squashed commit at the tip of the Remote Code Repository use the f
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(feature/MYFEATURE) ✗ git commit -m "Combining all MYFEATURE Commits in to a single Commit ID"
@@ -317,7 +317,7 @@ To push the rebased commit up to the Remote Code Repository use the following Gi
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(feature/MYFEATURE) git push origin feature/MYFEATURE
@@ -347,7 +347,7 @@ To cherry pick the squashed feature commit use the following Git command:
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(evn-x) git cherry-pick 294235aa042c7dadd84ecd6b33ce7d02818c291d
@@ -372,7 +372,7 @@ To finalize a feature branch use the following GitFlow command:
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(feature/MYFEATURE) git flow feature finish MYFEATURE
@@ -399,7 +399,7 @@ To push the finalized work up to the remote repository use the following Git com
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(develop) git push origin develop
@@ -425,7 +425,7 @@ To push the branch removal up to the remote repository use the following Git com
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(develop) git push origin develop
@@ -454,7 +454,7 @@ To create a release branch use the following GitFlow command:
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(develop) git flow release start 1.2.0
@@ -482,7 +482,7 @@ To push the new branch to the Remote Code Repository use the following Git comma
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(release/1.2.0) git flow release publish 1.2.0
@@ -525,7 +525,7 @@ To finalize the release use the following GitFlow command:
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(master) git flow  release finish 1.2.0
@@ -549,7 +549,7 @@ To push the finalized release to the Remote Code Repository use the following Gi
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(master) git push origin master
@@ -570,7 +570,7 @@ Now make sure Develop has the latest release.  Ideally there is no real update h
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(master) git push origin develop
@@ -584,7 +584,7 @@ The finalize command creates a release tag for you locally.  Push this release t
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(master) git push origin --tags
@@ -604,7 +604,7 @@ Finally, the release branch was removed locally when it was finalized.  Push the
 
 Example:
 
-.. code-block:: guess
+.. code-block:: bash
     :linenos:
 
     ➜  sandbox git:(master) git push origin :release/1.2.0

--- a/source/developers/in-context-editing.rst
+++ b/source/developers/in-context-editing.rst
@@ -20,7 +20,8 @@ Enabling Authoring Support
 
 At the top of your page or component (whatever it is you are rendering, include the following) import:
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
 
 	<#import "/templates/system/common/cstudio-support.ftl" as studio/>
 
@@ -28,7 +29,8 @@ At the top of your page or component (whatever it is you are rendering, include 
 
 At the bottom of your template insert the following: (Note the example shows a traditional HTML page however other formats/levels of granularity are supported
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
 
 			<@studio.toolSupport/>
 		</body>
@@ -51,7 +53,8 @@ In context editing renders pencils on the screen that invoke editing controls wh
 
 To enable in-context editing simply add the following attribute to the container/element where you want to place the editing control
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
 
 	<@studio.iceAttr iceGroup="author"/>
 
@@ -79,7 +82,8 @@ Tag Attributes
 
 Example: 
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
 
 	<img <@studio.iceAttr iceGroup="image" label="Promo Image 1" /> src="${contentModel.image!""}" alt="${contentModel.alttext!""}"/>``
 
@@ -95,7 +99,8 @@ Drag and drop makes it easy for authors to visually assemble pages.  Authors sim
 
 To define a drop zone for components simply add the following attribute to the container element where you want your components to render
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
 
 	<@studio.componentContainerAttr target="bottomPromos" objectId=contentModel.objectId />
 
@@ -119,7 +124,8 @@ Tag Attributes
 
 Example:
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
 
 	<div class="span4 mb10" <@studio.componentContainerAttr target="bottomPromos" objectId=contentModel.objectId /> >
 		...
@@ -134,7 +140,8 @@ Rendering components from the target inside the container
 
 The template needs to render the components that are referenced. The basic code to do this looks like:
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
 
 	<#if contentModel.bottomPromos?? && contentModel.bottomPromos.item??>
 		<#list contentModel.bottomPromos1.item as module>
@@ -147,7 +154,8 @@ The template needs to render the components that are referenced. The basic code 
 Note that the code is simply iterating over the collection of objects and calling render component.  NO markup is being inserted in this example.  The component template is rendering itself.  It's up to you if you want to insert markup around sub-components.
 Full example of typical component drop zone
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
 
 	<div class="span4 mb10" <@studio.componentContainerAttr target="bottomPromos" objectId=contentModel.objectId /> >
 		<#if contentModel.bottomPromos?? && contentModel.bottomPromos.item??>
@@ -164,7 +172,8 @@ Identifying components in the template
 
 In order for authors to interact with components, to drag them around the screen for example the templating system must know how to identify them.  To identify a component simply add the following attribute to the outer most element in the component template's markup
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
 
 	<@studio.componentAttr path=contentModel.storeUrl />
 
@@ -191,7 +200,8 @@ Tag Attributes
 
 Example
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
 
 	<img <@studio.componentAttr path=contentModel.storeUrl ice=true /> src="${contentModel.image!""}" alt="${contentModel.alttext!""}" />
 
@@ -205,7 +215,8 @@ Engine Support
 
 At the top of your page or component (whatever it is you are rendering, include the following) import:
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
 
 	<#import "/templates/system/common/crafter-support.ftl" as crafter/>
 
@@ -219,7 +230,8 @@ Render Component
 
 Need to render a sub component of some kind? 
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
 
 	<@renderComponent component=module />
 
@@ -231,7 +243,8 @@ Render Components
 Need to iterate through a list of components and render them WITHOUT any additional markup?
 
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
 
 	<@crafter.renderComponents componentList=contentModel.bottomPromos />
 
@@ -242,7 +255,8 @@ Render RTE (Rich Text Editor Components)
 
 Have components that are inserted in to the rich text editor and need to render them?
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
 
 	<@crafter.renderRTEComponents />
 

--- a/source/developers/projects/core/api/content_store/children.rst
+++ b/source/developers/projects/core/api/content_store/children.rst
@@ -40,7 +40,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: text
 
   GET .../api/1/content_store/children.json?contextId=405ffc233d075b010536bd2eb786b86c&url=/site/website
 

--- a/source/developers/projects/core/api/content_store/descriptor.rst
+++ b/source/developers/projects/core/api/content_store/descriptor.rst
@@ -39,7 +39,7 @@ Example
 ^^^^^^^
 Request
 ^^^^^^^
-.. code-block:: guess
+.. code-block:: text
 
   GET .../api/1/content_store/descriptor.json?contextId=405ffc233d075b010536bd2eb786b86c&url=/site/website/index.xml
 

--- a/source/developers/projects/core/api/content_store/item.rst
+++ b/source/developers/projects/core/api/content_store/item.rst
@@ -39,7 +39,7 @@ Example
 ^^^^^^^
 Request
 ^^^^^^^
-.. code-block:: guess
+.. code-block:: text
 
   GET .../api/1/content_store/item.json?contextId=405ffc233d075b010536bd2eb786b86c&url=/site/website/index.xml
 

--- a/source/developers/projects/core/api/content_store/tree.rst
+++ b/source/developers/projects/core/api/content_store/tree.rst
@@ -42,7 +42,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: text
 
  GET .../api/1/content_store/tree.xml?contextId=405ffc233d075b010536bd2eb786b86c&url=/site/website/articles/2017
 

--- a/source/developers/projects/deployer/api/monitor/memory.rst
+++ b/source/developers/projects/deployer/api/monitor/memory.rst
@@ -42,7 +42,8 @@ Response
 
 ``Status 200 OK``
 
-.. code-block:: guess
+.. code-block:: json
+  :force:
   :linenos:
 
   {

--- a/source/developers/projects/deployer/api/target-management/get-all-targets.rst
+++ b/source/developers/projects/deployer/api/target-management/get-all-targets.rst
@@ -28,7 +28,7 @@ Example
 Request
 ^^^^^^^
 
-``GET .../api/1/target/get_all``
+``GET .../api/1/target/get-all``
 
 ^^^^^^^^
 Response

--- a/source/developers/projects/engine/api/index.rst
+++ b/source/developers/projects/engine/api/index.rst
@@ -11,7 +11,7 @@ Crafter Engine API
 
     Here's an example to get an Item from the content store:
 
-    .. code-block:: guess
+    .. code-block:: text
 
         http://localhost:8080/api/1/site/content_store/item.json?url=/site/website/index.xml&crafterSite=mysite
 

--- a/source/developers/projects/engine/api/templating-api.rst
+++ b/source/developers/projects/engine/api/templating-api.rst
@@ -29,7 +29,8 @@ Rendering Navigation
 Crafter Engine provides the option of rendering automatically the navigation for you, just by using the macro
 ``renderNavigation``:
 
-.. code-block:: guess
+.. code-block:: html
+  :force:
   :linenos:
   :caption: Using the Navigation Macro
 
@@ -56,7 +57,8 @@ Rendering Breadcrumbs
 Crafter also offers a ``renderBreadcrumb`` macro to easily generate a dynamic list with all the
 parent pages of a specific url.
 
-.. code-block:: guess
+.. code-block:: html
+  :force:
   :linenos:
   :caption: Using the Breadcrumb Macro
 
@@ -89,7 +91,8 @@ Engine includes a default implementation that can be found in ``templates/web/na
 and ``templates/web/navigation2/breadcrumb-macros.ftl`` but it also provides the option to use your
 own sets of macros, which you'll probably want since the navigation HTML is generally specific to the site.
 
-.. code-block:: guess
+.. code-block:: html
+  :force:
   :linenos:
   :caption: Default Nav Macros
 
@@ -123,7 +126,8 @@ own sets of macros, which you'll probably want since the navigation HTML is gene
      </li>
   </#macro>
 
-.. code-block:: guess
+.. code-block:: html
+  :force:
   :linenos:
   :caption: Default Breadcrumb Macros
 
@@ -138,7 +142,8 @@ own sets of macros, which you'll probably want since the navigation HTML is gene
 You can define your own macros in an additional Freemarker template and include and optional
 parameter with the namespace that was given in the ``import`` tag:
 
-.. code-block:: guess
+.. code-block:: html
+  :force:
   :linenos:
   :caption: Using Custom Navigation Macros
 
@@ -177,7 +182,8 @@ Running Scripts/Controllers
 
 Crafter Engine allows executing scripts/controllers from inside Freemarker templates by using the tag ``@crafter.controller``.  It requires a single parameter, ``path``, which is the path of the script/controller in the site:
 
-.. code-block:: guess
+.. code-block:: html
+   :force:
    :caption: Running Scripts/Controllers from inside Freemarker templates
 
    <@crafter.controller path=“/scripts/plugins/MyPlugin/1/get-tweets.groovy” />

--- a/source/developers/projects/profile/api/profile/attachment/all.rst
+++ b/source/developers/projects/profile/api/profile/attachment/all.rst
@@ -41,7 +41,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: text
 
   GET .../api/1/profile/59284659d4c650213cc2f3fc/attachments?accessTokenId=e8f5170c-877b-416f-b70f-4b09772f8e2d
 

--- a/source/developers/projects/profile/api/profile/attachment/details.rst
+++ b/source/developers/projects/profile/api/profile/attachment/details.rst
@@ -43,7 +43,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: text
 
   GET .../api/1/profile/59284659d4c650213cc2f3fc/attachment/picture1/details?accessTokenId=e8f5170c-877b-416f-b70f-4b09772f8e2d
 

--- a/source/developers/projects/profile/api/profile/attachment/get.rst
+++ b/source/developers/projects/profile/api/profile/attachment/get.rst
@@ -43,7 +43,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: text
 
   GET .../api/1/profile/59284659d4c650213cc2f3fc/attachment/picture1?accessTokenId=e8f5170c-877b-416f-b70f-4b09772f8e2d
 

--- a/source/developers/projects/profile/api/profile/attributes/get.rst
+++ b/source/developers/projects/profile/api/profile/attributes/get.rst
@@ -45,7 +45,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: text
 
   GET .../api/1/profile/592887d7d4c650213cc2f400/attributes?accessTokenId=e8f5170c-877b-416f-b70f-4b09772f8e2d
 

--- a/source/developers/projects/profile/api/profile/create.rst
+++ b/source/developers/projects/profile/api/profile/create.rst
@@ -58,11 +58,12 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: text
 
   POST .../api/1/profile/create
 
-.. code-block:: none
+.. code-block:: json
+  :force:
   :linenos:
 
   accessTokenId=e8f5170c-877b-416f-b70f-4b09772f8e2d

--- a/source/developers/projects/profile/api/profile/verification_token/create.rst
+++ b/source/developers/projects/profile/api/profile/verification_token/create.rst
@@ -45,7 +45,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: text
 
   POST .../api/1/profile/592715d4d4c650e226b03b62/verification_token/create?accessTokenId=e8f5170c-877b-416f-b70f-4b09772f8e2d
 

--- a/source/developers/projects/profile/api/profile/verification_token/delete.rst
+++ b/source/developers/projects/profile/api/profile/verification_token/delete.rst
@@ -45,7 +45,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: text
 
   POST .../api/1/profile/verification_token/de60f56d-3a4b-4dec-b798-fb22b2964c14/delete?accessTokenId=e8f5170c-877b-416f-b70f-4b09772f8e2d
 

--- a/source/developers/projects/profile/api/profile/verification_token/get.rst
+++ b/source/developers/projects/profile/api/profile/verification_token/get.rst
@@ -41,7 +41,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: text
 
   GET .../api/1/profile/verification_token/de60f56d-3a4b-4dec-b798-fb22b2964c14?accessTokenId=e8f5170c-877b-416f-b70f-4b09772f8e2d
 

--- a/source/developers/projects/search/api/search/v2/update-content.rst
+++ b/source/developers/projects/search/api/search/v2/update-content.rst
@@ -53,7 +53,7 @@ Request
 
   POST .../api/2/search/update-content
 
-.. code-block:: guess
+.. code-block:: none
 
   index_id = editorial
   site = editorial

--- a/source/developers/projects/social/api/v3/system/context/add-profile.rst
+++ b/source/developers/projects/social/api/v3/system/context/add-profile.rst
@@ -49,7 +49,7 @@ Request
 
   POST .../api/3/system/context/e41e7273-b504-4d50-9edd-3b215eff6464/596683c030047dc279c21d27
 
-.. code-block:: guess
+.. code-block:: none
 
   context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
   roles=SOCIAL_USER

--- a/source/developers/projects/social/api/v3/system/context/create.rst
+++ b/source/developers/projects/social/api/v3/system/context/create.rst
@@ -44,7 +44,7 @@ Request
 
   POST .../api/3/system/context?context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
 
-.. code-block:: guess
+.. code-block:: none
 
   contextName=site1
 

--- a/source/developers/projects/social/api/v3/system/context/preferences-delete.rst
+++ b/source/developers/projects/social/api/v3/system/context/preferences-delete.rst
@@ -44,7 +44,7 @@ Request
 
   POST .../api/3/system/context/deletePreferences
 
-.. code-block:: guess
+.. code-block:: none
 
   context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
   preferences=customPref

--- a/source/developers/projects/social/api/v3/system/context/preferences-email-config-update.rst
+++ b/source/developers/projects/social/api/v3/system/context/preferences-email-config-update.rst
@@ -66,7 +66,7 @@ Request
 
   POST .../api/3/system/context/preferences/email/config
 
-.. code-block:: guess
+.. code-block:: none
 
   context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
   password=passw0rd

--- a/source/developers/projects/social/api/v3/system/context/preferences-email-template-update.rst
+++ b/source/developers/projects/social/api/v3/system/context/preferences-email-template-update.rst
@@ -55,7 +55,7 @@ Request
 
   POST .../api/3/system/context/preferences/email
 
-.. code-block:: guess
+.. code-block:: none
 
   template=Sample template for email
   type=INSTANT

--- a/source/developers/projects/social/api/v3/system/context/preferences-update.rst
+++ b/source/developers/projects/social/api/v3/system/context/preferences-update.rst
@@ -47,7 +47,7 @@ Request
 
   POST .../api/3/system/context/updatePreference
 
-.. code-block:: guess
+.. code-block:: none
 
   context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
   moderateByMailEnable=true

--- a/source/developers/projects/social/api/v3/system/context/remove-profile.rst
+++ b/source/developers/projects/social/api/v3/system/context/remove-profile.rst
@@ -46,7 +46,7 @@ Request
 
   POST .../api/3/system/context/e41e7273-b504-4d50-9edd-3b215eff6464/596683c030047dc279c21d27/delete
 
-.. code-block:: guess
+.. code-block:: none
 
   context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
 

--- a/source/developers/projects/social/api/v3/ugc/attachments/create.rst
+++ b/source/developers/projects/social/api/v3/ugc/attachments/create.rst
@@ -46,7 +46,7 @@ Request
 
   POST .../api/3/comments/59678d3f300426156e21df50/attachments?context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
 
-.. code-block:: guess
+.. code-block:: none
 
   Binary content
 

--- a/source/developers/projects/social/api/v3/ugc/comments/create.rst
+++ b/source/developers/projects/social/api/v3/ugc/comments/create.rst
@@ -58,7 +58,7 @@ Request
 
   POST .../api/3/comments
 
-.. code-block:: guess
+.. code-block:: none
 
   context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
   body=This is the first comment!

--- a/source/developers/projects/social/api/v3/ugc/comments/delete-attributes.rst
+++ b/source/developers/projects/social/api/v3/ugc/comments/delete-attributes.rst
@@ -54,7 +54,8 @@ Request
 
   DELETE .../api/3/comments/59678d3f300426156e21df50/attributes?context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
 
-.. code-block:: guess
+.. code-block:: json
+  :force:
 
   attributes=custom.property,second.property
 

--- a/source/developers/projects/social/api/v3/ugc/comments/moderate.rst
+++ b/source/developers/projects/social/api/v3/ugc/comments/moderate.rst
@@ -46,7 +46,7 @@ Request
 
   PUT .../api/3/comments/59678d3f300426156e21df50/moderate?context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
 
-.. code-block:: guess
+.. code-block:: none
 
   status=APPROVED
 

--- a/source/developers/projects/social/api/v3/ugc/comments/search.rst
+++ b/source/developers/projects/social/api/v3/ugc/comments/search.rst
@@ -50,7 +50,7 @@ Request
 
   POST .../api/3/comments/search
 
-.. code-block:: guess
+.. code-block:: none
 
   context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
   search={ targetId: "Welcome" }

--- a/source/developers/projects/social/api/v3/ugc/comments/update-attributes.rst
+++ b/source/developers/projects/social/api/v3/ugc/comments/update-attributes.rst
@@ -48,7 +48,7 @@ Request
 
   PUT .../api/3/comments/59678d3f300426156e21df50?context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
 
-.. code-block:: guess
+.. code-block:: none
 
   customProperty=true
 

--- a/source/developers/projects/social/api/v3/ugc/comments/update-flags.rst
+++ b/source/developers/projects/social/api/v3/ugc/comments/update-flags.rst
@@ -46,7 +46,7 @@ Request
 
   POST .../api/3/comments/59678d3f300426156e21df50/flags?context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
 
-.. code-block:: guess
+.. code-block:: none
 
   reason=Contains offensive language
 

--- a/source/developers/projects/social/api/v3/ugc/comments/update.rst
+++ b/source/developers/projects/social/api/v3/ugc/comments/update.rst
@@ -57,7 +57,7 @@ Request
 
   PUT .../api/3/comments/59678d3f300426156e21df50?context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
 
-.. code-block:: guess
+.. code-block:: none
 
 	body=This was the first comment in the site!
 

--- a/source/developers/projects/social/api/v3/ugc/threads/subscribe-update.rst
+++ b/source/developers/projects/social/api/v3/ugc/threads/subscribe-update.rst
@@ -53,7 +53,7 @@ Request
 
   POST .../api/3/threads/Welcome/subscribe/update
 
-.. code-block:: guess
+.. code-block:: none
 
   context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
   frequency=daily

--- a/source/developers/projects/social/api/v3/ugc/threads/subscribe.rst
+++ b/source/developers/projects/social/api/v3/ugc/threads/subscribe.rst
@@ -53,7 +53,7 @@ Request
 
   POST .../api/3/threads/Welcome/subscribe
 
-.. code-block:: guess
+.. code-block:: none
 
   context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
   frequency=weekly

--- a/source/developers/projects/social/api/v3/ugc/threads/unsubscribe.rst
+++ b/source/developers/projects/social/api/v3/ugc/threads/unsubscribe.rst
@@ -44,7 +44,7 @@ Request
 
   DELETE .../api/3/threads/Welcome/unsubscribe
 
-.. code-block:: guess
+.. code-block:: none
 
   context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
 

--- a/source/developers/projects/social/api/v3/ugc/votes/vote-down.rst
+++ b/source/developers/projects/social/api/v3/ugc/votes/vote-down.rst
@@ -44,7 +44,7 @@ Request
 
   PUT .../api/3/comments/59678d3f300426156e21df50/votes/down
 
-.. code-block:: guess
+.. code-block:: none
 
   context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
 

--- a/source/developers/projects/social/api/v3/ugc/votes/vote-neutral.rst
+++ b/source/developers/projects/social/api/v3/ugc/votes/vote-neutral.rst
@@ -44,7 +44,7 @@ Request
 
   PUT .../api/3/comments/59678d3f300426156e21df50/votes/neutral
 
-.. code-block:: guess
+.. code-block:: none
 
   context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
 

--- a/source/developers/projects/social/api/v3/ugc/votes/vote-up.rst
+++ b/source/developers/projects/social/api/v3/ugc/votes/vote-up.rst
@@ -44,7 +44,7 @@ Request
 
   PUT .../api/3/comments/59678d3f300426156e21df50/votes/up
 
-.. code-block:: guess
+.. code-block:: none
 
   context=f5b143c2-f1c0-4a10-b56e-f485f00d3fe9
 

--- a/source/developers/projects/studio/api/activity/get-user-activity.rst
+++ b/source/developers/projects/studio/api/activity/get-user-activity.rst
@@ -47,7 +47,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/activity/get-user-activities.json?site_id=mysite&user=jane.doe&num=10&excludeLive=false&filterType=all``
 
@@ -57,7 +57,8 @@ Response
 
 ``Status 200 OK``
 
-.. code-block:: guess
+.. code-block:: json
+  :force:
   :linenos:
 
   {

--- a/source/developers/projects/studio/api/activity/post-activity.rst
+++ b/source/developers/projects/studio/api/activity/post-activity.rst
@@ -47,7 +47,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST .../api/1/services/api/1/activity/post-activity.json?site_id=mysite&user=jane.doe&path=/site/website/index.xml&activity=UPDATE&contentTypeClass=pages``
 
@@ -57,7 +57,7 @@ Response
 
 ``Status 200 OK``
 
-.. code-block:: guess
+.. code-block:: text
 
   No response body
 

--- a/source/developers/projects/studio/api/clipboard/copy-item.rst
+++ b/source/developers/projects/studio/api/clipboard/copy-item.rst
@@ -40,7 +40,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST .../api/1/services/api/1/clipboard/copy-item.json?site_id=mysite
 

--- a/source/developers/projects/studio/api/clipboard/cut-item.rst
+++ b/source/developers/projects/studio/api/clipboard/cut-item.rst
@@ -39,7 +39,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST .../api/1/services/api/1/clipboard/cut-item.json?site_id=mysite
 

--- a/source/developers/projects/studio/api/clipboard/get-items.rst
+++ b/source/developers/projects/studio/api/clipboard/get-items.rst
@@ -40,7 +40,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/clipboard/get-items.json?site_id=mysite
 

--- a/source/developers/projects/studio/api/clipboard/paste-item.rst
+++ b/source/developers/projects/studio/api/clipboard/paste-item.rst
@@ -42,7 +42,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/clipboard/paste-item.json?site_id=mysite&parentPath=/site/website/folder2
 

--- a/source/developers/projects/studio/api/content/change-content-type.rst
+++ b/source/developers/projects/studio/api/content/change-content-type.rst
@@ -44,7 +44,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST .../api/1/services/api/1/content/change-content-type.json?site_id=mysite&path=/site/website/health/index.xml&contentType=/page/generic
 
@@ -54,7 +54,7 @@ Response
 
 ``Status 200 OK``
 
-.. code-block:: guess
+.. code-block:: text
 
     N/A
 

--- a/source/developers/projects/studio/api/content/content-exists.rst
+++ b/source/developers/projects/studio/api/content/content-exists.rst
@@ -42,7 +42,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/content-exists.json?site_id=mysite&path=/site/website/health/index.xml
 

--- a/source/developers/projects/studio/api/content/create-folder.rst
+++ b/source/developers/projects/studio/api/content/create-folder.rst
@@ -44,7 +44,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST .../api/1/services/api/1/content/create-folder.json?site_id=mysite&path=/site/website&name=newFolder
 

--- a/source/developers/projects/studio/api/content/crop-image.rst
+++ b/source/developers/projects/studio/api/content/crop-image.rst
@@ -52,7 +52,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/get-content.json?site_id=mysite&path=/static-assets/images/image1.png&newname=cropped.png&t=10&l=10&w=10&h=10
 
@@ -62,7 +62,7 @@ Response
 
 ``Status 200 OK``
 
-.. code-block:: guess
+.. code-block:: json
 
     { "success":true }
 

--- a/source/developers/projects/studio/api/content/get-content-at-path.rst
+++ b/source/developers/projects/studio/api/content/get-content-at-path.rst
@@ -42,7 +42,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/get-content-at-path.json?site_id=mysite&path=/site/website/health/index.xml
 
@@ -52,7 +52,8 @@ Response
 
 ``Status 200 OK``
 
-.. code-block:: guess
+.. code-block:: json
+   :force:
 
     content
 

--- a/source/developers/projects/studio/api/content/get-content-type.rst
+++ b/source/developers/projects/studio/api/content/get-content-type.rst
@@ -42,7 +42,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/get-content-type.json?site_id=mysite&type=/page/category-landing
 

--- a/source/developers/projects/studio/api/content/get-content-types.rst
+++ b/source/developers/projects/studio/api/content/get-content-types.rst
@@ -42,7 +42,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/get-content-type.jsons?site_id=mysite&type=/site/website
 

--- a/source/developers/projects/studio/api/content/get-content.rst
+++ b/source/developers/projects/studio/api/content/get-content.rst
@@ -44,7 +44,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/get-content.json?site_id=mysite&path=/site/website/health/index.xml&edit=true
 
@@ -54,7 +54,7 @@ Response
 
 ``Status 200 OK``
 
-.. code-block:: guess
+.. code-block:: text
 
     content
 

--- a/source/developers/projects/studio/api/content/get-item-orders.rst
+++ b/source/developers/projects/studio/api/content/get-item-orders.rst
@@ -42,7 +42,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/get-item-orders.json?site_id=mysite&path=/site/website/style/index.xml&edit=true
 

--- a/source/developers/projects/studio/api/content/get-item-states.rst
+++ b/source/developers/projects/studio/api/content/get-item-states.rst
@@ -42,7 +42,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/get-item-states.json?site_id=mysite&state=ALL
 

--- a/source/developers/projects/studio/api/content/get-item-versions.rst
+++ b/source/developers/projects/studio/api/content/get-item-versions.rst
@@ -42,7 +42,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/get-item-versions.json?site_id=mysite&path=/site/website/index.xml
 

--- a/source/developers/projects/studio/api/content/get-item.rst
+++ b/source/developers/projects/studio/api/content/get-item.rst
@@ -42,7 +42,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/get-item.json?site_id=mysite&path=/site/website/index.xml&edit=true
 

--- a/source/developers/projects/studio/api/content/get-items-tree.rst
+++ b/source/developers/projects/studio/api/content/get-items-tree.rst
@@ -44,7 +44,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/get-items-tree.json?site_id=mysite&path=/site/website/index.xml&depth=1
 

--- a/source/developers/projects/studio/api/content/get-next-item-order.rst
+++ b/source/developers/projects/studio/api/content/get-next-item-order.rst
@@ -42,7 +42,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/get-next-item-order.json?site_id=mysite&path=/site/website/index.xml
 

--- a/source/developers/projects/studio/api/content/get-pages.rst
+++ b/source/developers/projects/studio/api/content/get-pages.rst
@@ -46,7 +46,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/get-pages.json?site_id=mysite&path=/site/website/index.xml&depth=1&order=default
 

--- a/source/developers/projects/studio/api/content/rename-folder.rst
+++ b/source/developers/projects/studio/api/content/rename-folder.rst
@@ -44,7 +44,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST .../api/1/services/api/1/content/rename-folder.json?site_id=mysite&path=/site/website/oldFolder&name=newFolder
 

--- a/source/developers/projects/studio/api/content/reorder-items.rst
+++ b/source/developers/projects/studio/api/content/reorder-items.rst
@@ -46,7 +46,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/reorder-items.json?site_id=mysitet&path=/site/website/health/index.xml&before=/site/website/entertainment/index.xml&after=/site/website/technology/index.xml
 

--- a/source/developers/projects/studio/api/content/revert-content.rst
+++ b/source/developers/projects/studio/api/content/revert-content.rst
@@ -44,7 +44,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/revert-content.json?site_id=mysite&path=/site/website/style/index.xml&version=818e0f68bfccda9a9a1a788341b87ca3ba5ad3c6
 

--- a/source/developers/projects/studio/api/content/search.rst
+++ b/source/developers/projects/studio/api/content/search.rst
@@ -60,7 +60,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST ../api/1/services/api/1/content/search.json?site_id=mysite
 

--- a/source/developers/projects/studio/api/content/set-item-state.rst
+++ b/source/developers/projects/studio/api/content/set-item-state.rst
@@ -46,7 +46,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST ../api/1/services/api/1/content/set-item-state.json?site_id=mysite&path=/config/studio/administration/config-list.xml&state=EXISTING_UNEDITED_UNLOCKED&systemprocessing=false
 

--- a/source/developers/projects/studio/api/content/unlock-content.rst
+++ b/source/developers/projects/studio/api/content/unlock-content.rst
@@ -42,7 +42,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/content/unlock-content.json?site_id=mysite&path=/site/website/technology/index.xml
 

--- a/source/developers/projects/studio/api/content/write-content.rst
+++ b/source/developers/projects/studio/api/content/write-content.rst
@@ -61,13 +61,13 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST ../api/1/services/api/1/content/write-content.json?site_id=mysite&phase=onSave&path=/site/website/index.xml&fileName=index.xml&user=admin&contentType=/page/home&unlock=true
 
 |
 
-.. code-block:: guess
+.. code-block:: xml
     :caption: Request body
 
     <page>
@@ -185,13 +185,14 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST ../api/1/services/api/1/content/write-content.json?site_id=mysite&phase=onSave&path=/templates/web/pages&fileName=home.ftl&user=admin&unlock=true
 
 |
 
-.. code-block:: guess
+.. code-block:: html
+    :force:
     :caption: Request body
 
     <#import "/templates/system/common/cstudio-support.ftl" as studio />
@@ -361,7 +362,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST ../api/1/services/api/1/content/write-content.json?site_id=mysite&phase=onSave&path=/static-assets&fileName=undefined&user=admin&unlock=true
 
@@ -380,7 +381,7 @@ This request needs to be sent with ``Content-Type=multipart/form-data`` with the
 
 Your request payload should look like this:
 
-.. code-block:: guess
+.. code-block:: text
 
    ------WebKitFormBoundaryl9p1lhdx4gWpuCMM
    Content-Disposition: form-data; name="site"

--- a/source/developers/projects/studio/api/dependency/calculate-dependencies.rst
+++ b/source/developers/projects/studio/api/dependency/calculate-dependencies.rst
@@ -38,7 +38,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	POST .../api/1/services/api/1/dependency/calculate-dependencies.json?site_id=mysite
 

--- a/source/developers/projects/studio/api/dependency/get-dependant.rst
+++ b/source/developers/projects/studio/api/dependency/get-dependant.rst
@@ -42,7 +42,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST .../api/1/services/api/1/dependency/get-dependant.json?site_id=mysite&path=/templates/web/pages/home.ftl
 

--- a/source/developers/projects/studio/api/dependency/get-dependencies.rst
+++ b/source/developers/projects/studio/api/dependency/get-dependencies.rst
@@ -38,11 +38,12 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	POST .../api/1/services/api/1/dependency/get-dependencies.json?site_id=mysite
 
-.. code-block:: guess
+.. code-block:: json
+    :force:
 
     [
         {

--- a/source/developers/projects/studio/api/dependency/get-simple-dependencies.rst
+++ b/source/developers/projects/studio/api/dependency/get-simple-dependencies.rst
@@ -38,7 +38,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	POST ../api/1/services/api/1/dependency/get-simple-dependencies.json?site_id=mysite&path=/site/website/index.xml
 

--- a/source/developers/projects/studio/api/deployment/bulk-golive.rst
+++ b/source/developers/projects/studio/api/deployment/bulk-golive.rst
@@ -44,7 +44,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST .../api/1/services/api/1/deployment/bulk-golive.json?site_id=mysite&path=/site/website&environment=Live
 

--- a/source/developers/projects/studio/api/deployment/get-available-publishing-channels.rst
+++ b/source/developers/projects/studio/api/deployment/get-available-publishing-channels.rst
@@ -41,7 +41,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/deployment/get-available-publishing-channels.json?site_id=mysite
 

--- a/source/developers/projects/studio/api/deployment/get-deployment-history.rst
+++ b/source/developers/projects/studio/api/deployment/get-deployment-history.rst
@@ -46,7 +46,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/deployment/get-deployment-history.json?site_id=mysite&days=30&num=10&filterType=all
 

--- a/source/developers/projects/studio/api/deployment/get-scheduled-items.rst
+++ b/source/developers/projects/studio/api/deployment/get-scheduled-items.rst
@@ -46,7 +46,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/deployment/get-scheduled-items.json?site_id=mysite&sort=eventDate&ascending=false&filterType=all
 

--- a/source/developers/projects/studio/api/group-management/add-user.rst
+++ b/source/developers/projects/studio/api/group-management/add-user.rst
@@ -40,7 +40,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	POST .../api/1/services/api/1/group/add-user.json
 

--- a/source/developers/projects/studio/api/group-management/create-group.rst
+++ b/source/developers/projects/studio/api/group-management/create-group.rst
@@ -40,7 +40,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	POST .../api/1/services/api/1/group/create.json
 

--- a/source/developers/projects/studio/api/group-management/delete-group.rst
+++ b/source/developers/projects/studio/api/group-management/delete-group.rst
@@ -38,7 +38,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	POST .../api/1/services/api/1/group/delete.json
 

--- a/source/developers/projects/studio/api/group-management/get-group.rst
+++ b/source/developers/projects/studio/api/group-management/get-group.rst
@@ -38,7 +38,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/group/get.json?group_name=contributors&site_id=mysite
 

--- a/source/developers/projects/studio/api/group-management/get-groups-per-site.rst
+++ b/source/developers/projects/studio/api/group-management/get-groups-per-site.rst
@@ -40,7 +40,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/group/get-per-site.json?site_id="mysite"
 

--- a/source/developers/projects/studio/api/group-management/get-groups.rst
+++ b/source/developers/projects/studio/api/group-management/get-groups.rst
@@ -38,7 +38,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/group/get-all.json?start=0&number=25
 

--- a/source/developers/projects/studio/api/group-management/get-users.rst
+++ b/source/developers/projects/studio/api/group-management/get-users.rst
@@ -42,7 +42,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/group/users.json?group_name=mygroup&site_id=mysite
 

--- a/source/developers/projects/studio/api/group-management/remove-user.rst
+++ b/source/developers/projects/studio/api/group-management/remove-user.rst
@@ -40,7 +40,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	POST .../api/1/services/api/1/group/remove-user.json
 

--- a/source/developers/projects/studio/api/group-management/update-group.rst
+++ b/source/developers/projects/studio/api/group-management/update-group.rst
@@ -40,7 +40,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	POST .../api/1/services/api/1/group/update.json
 

--- a/source/developers/projects/studio/api/monitor/memory.rst
+++ b/source/developers/projects/studio/api/monitor/memory.rst
@@ -45,7 +45,8 @@ Response
 
 ``Status 200 OK``
 
-.. code-block:: guess
+.. code-block:: json
+  :force:
   :linenos:
 
   {

--- a/source/developers/projects/studio/api/preview/sync-site.rst
+++ b/source/developers/projects/studio/api/preview/sync-site.rst
@@ -40,7 +40,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST .../api/1/services/api/1/preview/sync-site.json?site_id=mysite
 

--- a/source/developers/projects/studio/api/publish/commits.rst
+++ b/source/developers/projects/studio/api/publish/commits.rst
@@ -46,7 +46,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST .../api/1/services/api/1/publish/commits.json
 

--- a/source/developers/projects/studio/api/publish/publish-items.rst
+++ b/source/developers/projects/studio/api/publish/publish-items.rst
@@ -45,7 +45,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	POST .../api/1/services/api/1/publish/publish-items.json?site_id=mysite
 

--- a/source/developers/projects/studio/api/security/get-user-permissions.rst
+++ b/source/developers/projects/studio/api/security/get-user-permissions.rst
@@ -40,7 +40,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/security/get-user-permissions.json?site_id=mysite&path=/site/website/style/index.xml&user=admin
 

--- a/source/developers/projects/studio/api/security/get-user-roles.rst
+++ b/source/developers/projects/studio/api/security/get-user-roles.rst
@@ -38,7 +38,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/security/get-user-roles.json?site_id=mysite&user=admin
 

--- a/source/developers/projects/studio/api/security/validate-session.rst
+++ b/source/developers/projects/studio/api/security/validate-session.rst
@@ -32,7 +32,7 @@ None.
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/security/validate-session.json
 

--- a/source/developers/projects/studio/api/server/get-available-languages.rst
+++ b/source/developers/projects/studio/api/server/get-available-languages.rst
@@ -27,7 +27,7 @@ Resource Information
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/server/get-available-languages.json
 

--- a/source/developers/projects/studio/api/server/get-loggers.rst
+++ b/source/developers/projects/studio/api/server/get-loggers.rst
@@ -27,7 +27,7 @@ Resource Information
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/server/get-loggers.json
 

--- a/source/developers/projects/studio/api/server/get-ui-resource-override.rst
+++ b/source/developers/projects/studio/api/server/get-ui-resource-override.rst
@@ -37,7 +37,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/server/get-ui-resource-override.json?resource=logo.jpg
 

--- a/source/developers/projects/studio/api/server/set-logger-state.rst
+++ b/source/developers/projects/studio/api/server/set-logger-state.rst
@@ -39,7 +39,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/server/set-logger-state.json?logger=org.craftercms.studio.impl.v1.service.content.ContentServiceImpl&level=debug
 

--- a/source/developers/projects/studio/api/site/clear-configuration-cache.rst
+++ b/source/developers/projects/studio/api/site/clear-configuration-cache.rst
@@ -27,7 +27,7 @@ Resource Information
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/site/clear-configuration-cache.json?site_id=mysite
 

--- a/source/developers/projects/studio/api/site/create-site.rst
+++ b/source/developers/projects/studio/api/site/create-site.rst
@@ -82,7 +82,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	POST .../api/1/services/api/1/site/create.json
 

--- a/source/developers/projects/studio/api/site/delete-site.rst
+++ b/source/developers/projects/studio/api/site/delete-site.rst
@@ -36,7 +36,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	POST .../api/1/services/api/1/site/delete-site.json
 

--- a/source/developers/projects/studio/api/site/exists.rst
+++ b/source/developers/projects/studio/api/site/exists.rst
@@ -36,7 +36,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/site/exists.json?site_id=mysite
 

--- a/source/developers/projects/studio/api/site/get-available-blueprints.rst
+++ b/source/developers/projects/studio/api/site/get-available-blueprints.rst
@@ -26,7 +26,7 @@ Resource Information
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/site/get-available-blueprints.json
 

--- a/source/developers/projects/studio/api/site/get-canned-message.rst
+++ b/source/developers/projects/studio/api/site/get-canned-message.rst
@@ -44,7 +44,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/site/get-canned-message.json?site_id=mysite&locale=en&type=NotApproved
 

--- a/source/developers/projects/studio/api/site/get-configuration.rst
+++ b/source/developers/projects/studio/api/site/get-configuration.rst
@@ -42,7 +42,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/site/get-configuration.json?site_id=mysite&path=/site-config.xml
 

--- a/source/developers/projects/studio/api/site/get-site.rst
+++ b/source/developers/projects/studio/api/site/get-site.rst
@@ -36,7 +36,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/site/get.json?site_id=my-site
 

--- a/source/developers/projects/studio/api/site/get-sites-per-user.rst
+++ b/source/developers/projects/studio/api/site/get-sites-per-user.rst
@@ -40,7 +40,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/site/get-per-user.json?username=jane.doe
 

--- a/source/developers/projects/studio/api/site/monitor-content.rst
+++ b/source/developers/projects/studio/api/site/monitor-content.rst
@@ -27,11 +27,12 @@ Resource Information
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/site/monitor-content.json
 
-.. code-block:: guess
+.. code-block:: json
+   :force:
 
    [
      {

--- a/source/developers/projects/studio/api/site/write-configuration.rst
+++ b/source/developers/projects/studio/api/site/write-configuration.rst
@@ -38,7 +38,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	POST .../api/1/services/api/1/site/write-configuration.json?site_id=mysite&path=/config/studio/site-config.xml
 

--- a/source/developers/projects/studio/api/user-management/change-password.rst
+++ b/source/developers/projects/studio/api/user-management/change-password.rst
@@ -40,7 +40,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	POST .../api/1/services/api/1/user/change-password.json
 

--- a/source/developers/projects/studio/api/user-management/create-user.rst
+++ b/source/developers/projects/studio/api/user-management/create-user.rst
@@ -44,7 +44,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	POST .../api/1/services/api/1/user/create.json
 

--- a/source/developers/projects/studio/api/user-management/delete-user.rst
+++ b/source/developers/projects/studio/api/user-management/delete-user.rst
@@ -36,7 +36,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	POST .../api/1/services/api/1/user/delete.json
 

--- a/source/developers/projects/studio/api/user-management/disable-user.rst
+++ b/source/developers/projects/studio/api/user-management/disable-user.rst
@@ -36,7 +36,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	POST .../api/1/services/api/1/user/disable.json
 

--- a/source/developers/projects/studio/api/user-management/enable-user.rst
+++ b/source/developers/projects/studio/api/user-management/enable-user.rst
@@ -36,7 +36,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	POST .../api/1/services/api/1/user/enable.json
 

--- a/source/developers/projects/studio/api/user-management/forgot-password.rst
+++ b/source/developers/projects/studio/api/user-management/forgot-password.rst
@@ -36,7 +36,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/user/forgot-password.json?username=jane.doe
 

--- a/source/developers/projects/studio/api/user-management/get-user-status.rst
+++ b/source/developers/projects/studio/api/user-management/get-user-status.rst
@@ -36,7 +36,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/user/status.json?username=jane.doe
 

--- a/source/developers/projects/studio/api/user-management/get-user.rst
+++ b/source/developers/projects/studio/api/user-management/get-user.rst
@@ -36,7 +36,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/user/get.json?username=jane.doe
 

--- a/source/developers/projects/studio/api/user-management/get-users-per-site.rst
+++ b/source/developers/projects/studio/api/user-management/get-users-per-site.rst
@@ -40,7 +40,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/user/get-per-site.json?site_id=my-site
 

--- a/source/developers/projects/studio/api/user-management/get-users.rst
+++ b/source/developers/projects/studio/api/user-management/get-users.rst
@@ -38,7 +38,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/user/get-all.json?start=0&number=25
 

--- a/source/developers/projects/studio/api/user-management/reset-password.rst
+++ b/source/developers/projects/studio/api/user-management/reset-password.rst
@@ -38,7 +38,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	POST .../api/1/services/api/1/user/reset-password.json
 

--- a/source/developers/projects/studio/api/user-management/set-password.rst
+++ b/source/developers/projects/studio/api/user-management/set-password.rst
@@ -38,7 +38,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	POST .../api/1/services/api/1/user/set-password.json
 

--- a/source/developers/projects/studio/api/user-management/set-password.rst2
+++ b/source/developers/projects/studio/api/user-management/set-password.rst2
@@ -39,7 +39,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	POST .../api/1/services/api/1/user/set-password.json
 

--- a/source/developers/projects/studio/api/user-management/update-user.rst
+++ b/source/developers/projects/studio/api/user-management/update-user.rst
@@ -42,7 +42,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	POST .../api/1/services/api/1/user/update.json
 

--- a/source/developers/projects/studio/api/user-management/validate-token.rst
+++ b/source/developers/projects/studio/api/user-management/validate-token.rst
@@ -36,7 +36,7 @@ Parameters
 Example
 -------
 
-.. code-block:: guess
+.. code-block:: none
 
 	GET .../api/1/services/api/1/user/validate-token.json?token=asfopaiu02928s0980b98a098gs0fduoi2j341j448t735h1lk40
 

--- a/source/developers/projects/studio/api/workflow/create-jobs.rst
+++ b/source/developers/projects/studio/api/workflow/create-jobs.rst
@@ -42,7 +42,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST .../api/1/services/api/1/workflow/create-jobs.json?site_id=mysite&user=test
 

--- a/source/developers/projects/studio/api/workflow/get-go-live-items.rst
+++ b/source/developers/projects/studio/api/workflow/get-go-live-items.rst
@@ -46,7 +46,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/workflow/get-go-live-items.json?site_id=mysite&sort=eventDate&ascending=false
 

--- a/source/developers/projects/studio/api/workflow/get-workflow-affected-paths.rst
+++ b/source/developers/projects/studio/api/workflow/get-workflow-affected-paths.rst
@@ -42,7 +42,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     GET .../api/1/services/api/1/workflow/get-workflow-affected-paths.json?site_id=mysite&path=/site/website/index.xml
 
@@ -52,7 +52,8 @@ Response
 
 ``Status 200 OK``
 
-.. code-block:: guess
+.. code-block:: json
+    :force:
     :linenos:
 
     {

--- a/source/developers/projects/studio/api/workflow/go-delete.rst
+++ b/source/developers/projects/studio/api/workflow/go-delete.rst
@@ -44,7 +44,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST ../api/1/services/api/1/workflow/go-delete.json?deletedep=true&site_id=mysite&user=admin
 

--- a/source/developers/projects/studio/api/workflow/go-live.rst
+++ b/source/developers/projects/studio/api/workflow/go-live.rst
@@ -40,7 +40,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST .../api/1/services/api/1/workflow/go-live.json?site_id=mysite
 

--- a/source/developers/projects/studio/api/workflow/reject.rst
+++ b/source/developers/projects/studio/api/workflow/reject.rst
@@ -42,7 +42,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST .../api/1/services/api/1/workflow/reject.json?site_id=mysite&user=test
 

--- a/source/developers/projects/studio/api/workflow/submit-to-go-live.rst
+++ b/source/developers/projects/studio/api/workflow/submit-to-go-live.rst
@@ -45,7 +45,7 @@ Example
 Request
 ^^^^^^^
 
-.. code-block:: guess
+.. code-block:: none
 
     POST .../api/1/services/api/1/workflow/submit-to-go-live.json?site_id=mysite&user=author
 

--- a/source/developers/search.rst
+++ b/source/developers/search.rst
@@ -79,7 +79,8 @@ Create template variables with current cookie values
 
 As you can see, the code simply creates a template value for each user selection based on the value from the cookie.  If no cookie is found a default value (specified by !”FOO”) is provided. This code would typically appear close to the top of the template.
 
-.. code-block:: guess
+.. code-block:: html
+   :force:
 
    <#assign sort = (Cookies["category-sort"]!"")?replace("-", " ")>
    <#assign filterSize = (Cookies["category-filter-size"]!"*")>
@@ -90,7 +91,8 @@ Render controls with values selected from cookies
 
 Now we need to build the filter controls for our users so that they can narrow their searches. In the code below we’re iterating over the available options (we’ll show how these are acquired in just a moment) and creating the options for the select component.  For each option we look to see if it is the currently selected item and if so we mark it as selected.
 
-.. code-block:: guess
+.. code-block:: html
+   :force:
    :linenos:
 
    <select style="width: 90px"  onchange="setCookie('category-filter-color', this.value);">
@@ -105,7 +107,8 @@ Provide a  mechanism to save a selected value to our cookie and force a refresh
 
 In the code above you can see a simple JavaScript function on the “onChange” method for the select control.  Again you can see here we’re keeping the code as abstraction free as possible to make the example clear.  Below is the simple JavaScript function:
 
-.. code-block:: guess
+.. code-block:: js
+   :force:
    :linenos:
 
    <script>
@@ -127,7 +130,8 @@ Construct a query that is NOT constrained by filters.
 We will use the results of this query to get the possible values and counts for our filters.
 Below you can see we’re building up a simple query for the jeans content type, gender and collection.
 
-.. code-block:: guess
+.. code-block:: html
+   :force:
 
    <#assign queryStatement = 'content-type:"/component/jeans" ' />
    <#assign queryStatement = queryStatement + 'AND gender.item.key:"' + gender + '" ' />
@@ -139,7 +143,8 @@ Construct a query based on the first but with additional filter constraints
 
 We will use the results of this query to display the results to the user.
 
-.. code-block:: guess
+.. code-block:: html
+   :force:
 
    <#assign filteredQueryStatement = queryStatement />
    <#assign filteredQueryStatement = filteredQueryStatement + ‘AND size.item.value:”‘ + filterSize + ‘” ‘ />
@@ -150,7 +155,8 @@ Execute the unfiltered query
 
 Here you can see we’re declaring the facets we want the counts on.
 
-.. code-block:: guess
+.. code-block:: html
+   :force:
    :linenos:
 
    <#assign query = searchService.createQuery()>
@@ -165,7 +171,8 @@ Execute the filtered query
 
 Here you can see we’re declaring the pagination and sorting options.
 
-.. code-block:: guess
+.. code-block:: html
+   :force:
    :linenos:
 
    <#assign filteredQuery = searchService.createQuery()>
@@ -183,7 +190,8 @@ Assign the results to template variables
 
 Below you can see the how we’re getting the matching jean objects, and number of results returned from the filtered query response.  You can also see how we’re getting the available options and counts from the unfiltered query response.
 
-.. code-block:: guess
+.. code-block:: html
+   :force:
 
    <#assign productsFound = executedFilteredQuery.response.numFound>
    <#assign products = executedFilteredQuery.response.documents />
@@ -199,7 +207,8 @@ Display the products
 
 In the code below, we’re iterating over the available products and simply displaying the details for it.
 
-.. code-block:: guess
+.. code-block:: html
+   :force:
    :linenos:
 
    <#list products as product>
@@ -221,7 +230,8 @@ Construct pagination
 
 Given the number of items found and our productsPerPage value we can determine the number of pages to show to the user.
 
-.. code-block:: guess
+.. code-block:: html
+   :force:
    :linenos:
 
    <div>

--- a/source/site-administrators/engine/engine-mongodb-configuration.rst
+++ b/source/site-administrators/engine/engine-mongodb-configuration.rst
@@ -58,7 +58,7 @@ Use the client from a Groovy script
 
 We can now use the client from a Groovy script.  Here's a simple script that runs a query:
 
-.. code-block:: guess
+.. code-block:: js
     :linenos:
 
     def mongo = applicationContext.mongoClient

--- a/source/site-administrators/publishing-and-status.rst
+++ b/source/site-administrators/publishing-and-status.rst
@@ -56,7 +56,7 @@ To publish by commit id, let's use a site created using the Website Editorial bl
 - Edit the Home page (/site/website/index.xm) from the command line or anywhere other than Studio
 - From the command line, commit your changes
 
-  .. code-block:: guess
+  .. code-block:: bash
 
      $ cd crafter-authoring/data/repos/sites/mysite/sandbox/site/website
      $ git add .
@@ -64,7 +64,7 @@ To publish by commit id, let's use a site created using the Website Editorial bl
 
 - Get the commit id after doing the above step
 
-  .. code-block:: guess
+  .. code-block:: bash
 
      $ git log
      commit f47c9a5bae4184e7b5ff2cb03b90b8ff86adec37 (HEAD -> master)

--- a/source/system-administrators/activities/authoring/authoring-env-performance-tuning.rst
+++ b/source/system-administrators/activities/authoring/authoring-env-performance-tuning.rst
@@ -58,7 +58,7 @@ Testing Raw Performance
 
 	* Example
 
-      .. code-block:: guess
+      .. code-block:: text
           :linenos:
 
           Timing cached reads:   24486 MB in  1.99 seconds = 12284.28 MB/sec
@@ -70,7 +70,7 @@ Testing Raw Performance
 
 	* Example
 
-      .. code-block:: guess
+      .. code-block:: bash
          :linenos:
 
          $ fio --randrepeat=1 --ioengine=libaio --gtod_reduce=1 --name=test --filename=test --bs=4k --iodepth=64 --size=4G --readwrite=randrw --rwmixread=75
@@ -98,7 +98,7 @@ Testing Raw Performance
 
 	* Example
 
-      .. code-block:: guess
+      .. code-block:: bash
          :linenos:
 
 	     $ ioping -c 10 .
@@ -173,7 +173,7 @@ Crafter CMS includes many subsystems that require additional file-handles be ava
 
 Our limits are:
 
-.. code-block:: guess
+.. code-block:: none
     :linenos:
 
     [Service]

--- a/source/system-administrators/activities/authoring/change-ports-on-your-auth-install.rst
+++ b/source/system-administrators/activities/authoring/change-ports-on-your-auth-install.rst
@@ -80,7 +80,7 @@ The default Deployer port is 9191.  There are a few places that we need to updat
 
 First, we'll configure the ports for the Deployer that affects your Studio.  Open the file ``INSTALL_DIR/bin/crafter-deployer/config/application.yaml`` and change the configured ports to the desired port by adding the following lines with your desired port number:
 
-    .. code-block:: guess
+    .. code-block:: yaml
 
         server:
             port: 9191

--- a/source/system-administrators/activities/debugging-search.rst
+++ b/source/system-administrators/activities/debugging-search.rst
@@ -109,7 +109,7 @@ Configure Crafter Engine: Crafter Search URL
 
 ``$CATALINA_HOME/shared/classes/crafter/engine/extension/server-config.properties``
 
-.. code-block:: guess
+.. code-block:: properties
 
   crafter.engine.search.server.url=http://HOST:PORT/crafter-search
 
@@ -119,6 +119,6 @@ Configure Crafter Search: Solr URL
 
 ``$CATALINA_HOME/shared/classes/crafter/search/extension/server-config.properties``
 
-.. code-block:: guess
+.. code-block:: properties
 
   crafter.search.solr.server.url=http://HOST:PORT/solr

--- a/source/system-administrators/activities/delivery/change-ports-on-your-delivery-install.rst
+++ b/source/system-administrators/activities/delivery/change-ports-on-your-delivery-install.rst
@@ -72,7 +72,7 @@ The default Deployer port is 9192.  There are a few places that we need to updat
 
 First, we'll configure the ports for the Deployer that affects your Studio.  Open the file ``DELIVERY_INSTALL_DIR/bin/crafter-deployer/config/application.yaml`` and change the configured ports to the desired port by adding the following lines with your desired port number:
 
-    .. code-block:: guess
+    .. code-block:: yaml
 
         server:
             port: 9192

--- a/source/system-administrators/activities/delivery/delivery-env-performance-tuning.rst
+++ b/source/system-administrators/activities/delivery/delivery-env-performance-tuning.rst
@@ -70,7 +70,7 @@ Testing Raw Performance
 
 	* Example
 
-      .. code-block:: guess
+      .. code-block:: text
           :linenos:
 
           Timing cached reads:   24486 MB in  1.99 seconds = 12284.28 MB/sec
@@ -82,7 +82,7 @@ Testing Raw Performance
 
 	* Example
 
-      .. code-block:: guess
+      .. code-block:: bash
          :linenos:
 
          $ fio --randrepeat=1 --ioengine=libaio --gtod_reduce=1 --name=test --filename=test --bs=4k --iodepth=64 --size=4G --readwrite=randrw --rwmixread=75
@@ -110,7 +110,7 @@ Testing Raw Performance
 
 	* Example
 
-      .. code-block:: guess
+      .. code-block:: bash
          :linenos:
 
 	     $ ioping -c 10 .
@@ -184,7 +184,7 @@ Crafter CMS includes many subsystems that require additional file-handles be ava
 
 Our limits are:
 
-.. code-block:: guess
+.. code-block:: none
     :linenos:
 
     [Service]

--- a/source/system-administrators/activities/delivery/setup-site-for-delivery.rst
+++ b/source/system-administrators/activities/delivery/setup-site-for-delivery.rst
@@ -17,7 +17,8 @@ In the ``bin`` folder in your Crafter CMS delivery environment, we will use the 
 From your command line, navigate to your ``{Crafter-CMS-delivery-environment-directory}/bin/`` , and execute the init-site script. The following output of ``init-site.sh -h``
 explains how to use the script:
 
-  .. code-block:: guess
+  .. code-block:: bash
+    :force:
 
     usage: init-site [options] [site] [repo-path]
      -a,--notification-addresses <addresses>   A comma-separated list of email
@@ -75,7 +76,7 @@ Example #2: ``ssh://jdoe@server2.example.com:63022/path/to/repo``
 If you are just working on another directory on disk for your delivery, you can just use the filesystem.  When your repository is local, make sure to use the absolute path.
 Here is an example site's published repo Git url when using a local repository:
 
-  .. code-block:: guess
+  .. code-block:: bash
 
       /opt/crafter/authoring/data/repos/sites/mysite/published
 

--- a/source/system-administrators/activities/reindexing-content-in-prod.rst
+++ b/source/system-administrators/activities/reindexing-content-in-prod.rst
@@ -62,7 +62,7 @@ Step 5: Wait
 You will see indexing activity in the deployment log located in ``INSTALL_DIRECTORY/logs/deployer/crafter-deployer.out``. Indexing activity time is dependent
 on the amount of content which must be re-processed. When the deployment/indexing finishes you should see something like the following in the log:
 
-.. code-block:: guess
+.. code-block:: text
 
   2017-07-25 16:52:03.762  INFO 21896 --- [pool-2-thread-1] org.craftercms.deployer.impl.TargetImpl  : ------------------------------------------------------------
   2017-07-25 16:52:03.763  INFO 21896 --- [pool-2-thread-1] org.craftercms.deployer.impl.TargetImpl  : Deployment for editorial-tmp-prod finished in 2.359 secs

--- a/source/system-administrators/activities/reindexing-content.rst
+++ b/source/system-administrators/activities/reindexing-content.rst
@@ -96,7 +96,7 @@ To start reindexing/reprocessing, send the following CURL command:
 
 After sending the CURL command, you will get a response like this:
 
-.. code-block:: guess
+.. code-block:: json
 
    {"message":"OK"}
 
@@ -109,7 +109,7 @@ Step 3: Wait for indexing
 You will see indexing activity in the deployment log located in ``INSTALL_DIRECTORY/logs/deployer/crafter-deployer.out``. Indexing activity time is dependent on the amount of content which must be re-processed. When the
 deployment/indexing finishes you should see something like the following in the log:
 
-.. code-block:: guess
+.. code-block:: text
 
 	2017-07-25 16:52:03.762  INFO 21896 --- [pool-2-thread-1] org.craftercms.deployer.impl.TargetImpl  : ------------------------------------------------------------
 	2017-07-25 16:52:03.763  INFO 21896 --- [pool-2-thread-1] org.craftercms.deployer.impl.TargetImpl  : Deployment for editorial-preview finished in 2.359 secs

--- a/source/system-administrators/activities/security/configure-ldap.rst
+++ b/source/system-administrators/activities/security/configure-ldap.rst
@@ -62,7 +62,7 @@ created in the database with the imported LDAP attributes, and finally added to 
 
 Also, please note that Studio needs all the attributes listed in the config to be present in the LDAP user's attributes, otherwise, Studio is not able to authenticate the user.  When an attribute is missing, an error message will be displayed in the login screen: ``A system error has occurred.  Please wait a few minutes or contact an administrator``.  Please look at the tomcat log to check which attribute was not found.  Here's an example log:
 
-.. code-block:: guess
+.. code-block:: text
 
     [WARN] 2017-10-11 12:42:57,487 [http-nio-8080-exec-2] [security.DbWithLdapExtensionSecurityProvider] | No LDAP attribute crafterGroup found for username cbrunato
 

--- a/source/system-administrators/commons/encryption-tool.rst
+++ b/source/system-administrators/commons/encryption-tool.rst
@@ -13,28 +13,28 @@ sub-module, where you should find the JAR with the ``-enctool`` suffix. Then you
 
 - **Encode text in Base 64:** ``java -jar {JARNAME} -e64 CLEAR_TEXT``
 
-	.. code-block:: guess
+	.. code-block:: bash
 
 		java -jar crafter-commons-utilities-3.0.1-enctool.jar -e64 KniOddyi
 		Encoded text in Base 64: S25pT2RkeWk=
 
 - **Decode Base 64 text:** ``java -jar {JARNAME} -d64 BASE64_TEXT``
 
-	.. code-block:: guess
+	.. code-block:: bash
 
 		java -jar crafter-commons-utilities-3.0.1-enctool.jar -d64 S25pT2RkeWk=
 		Decoded Base 64 text: KniOddyi
 
 - **Encrypt text:** ``java -jar {JARNAME} -e CLEAR_TEXT -p PASSWORD -s BASE64_SALT``
 
-	.. code-block:: guess
+	.. code-block:: bash
 
 		java -jar crafter-commons-utilities-3.0.1-enctool.jar -e c852cb30cda311e488300800200c9a66 -p klanFogyetkonjo -s S25pT2RkeWk=
 		Cipher text (in Base 64): VkHxBsaSZ9DXrXk52uK9And+CEZlqiy7Wb23GxBFOSXD6KBOCh1ojp8fUw7w11IxpxBipiI4HsSg3cdl9TgTQg==
 
 - **Decrypt text:** ``java -jar {JARNAME} -d CIPHER_TEXT -p PASSWORD -s BASE64_SALT``
 
-	.. code-block:: guess
+	.. code-block:: bash
 
 		java -jar crafter-commons-utilities-3.0.1-enctool.jar -d VkHxBsaSZ9DXrXk52uK9And+CEZlqiy7Wb23GxBFOSXD6KBOCh1ojp8fUw7w11IxpxBipiI4HsSg3cdl9TgTQg== -p klanFogyetkonjo -s S25pT2RkeWk=
 		Clear text: c852cb30cda311e488300800200c9a66

--- a/source/system-administrators/deployer/admin-guide.rst
+++ b/source/system-administrators/deployer/admin-guide.rst
@@ -208,7 +208,7 @@ By default the processed commits are stored in a folder (``CRAFTER_HOME/data/dep
 as an individual file for each target (for example ``editorial-preview.commit``). Each file contains
 only the commit id that will be used to track the changes during deployments:
 
-.. code-block:: guess
+.. code-block:: text
   :caption: Example of a processed commit file
   :linenos:
   

--- a/source/system-administrators/profile/index.rst
+++ b/source/system-administrators/profile/index.rst
@@ -243,7 +243,7 @@ templates and configure Crafter Profile to use them following this steps:
 
 The templates will have available the ``verificationLink`` variable.
 
-.. code-block:: guess
+.. code-block:: html
   :caption: Example Email Template
 
   Click on the link below to verify your Crafter Profile account.

--- a/source/system-administrators/social/admin/guides/preferences.rst
+++ b/source/system-administrators/social/admin/guides/preferences.rst
@@ -40,7 +40,8 @@ This section includes Context specific templates for all supported event notific
 
 All email templates need to be valid HTML pages and can use any feature from Freemarker.
 
-.. code-block:: guess
+.. code-block:: html
+  :force:
   :caption: Example Email Template
   :linenos:
 

--- a/source/system-administrators/social/admin/index.rst
+++ b/source/system-administrators/social/admin/index.rst
@@ -43,7 +43,7 @@ properties file placed in the following location:
 
 You can change any of the default configuration, some of the more relevant properties are:
 
-.. code-block:: guess
+.. code-block:: properties
 
   crafter.social.app.rootUrl=
   crafter.social.app.name=crafter-social

--- a/source/system-administrators/social/index.rst
+++ b/source/system-administrators/social/index.rst
@@ -253,7 +253,7 @@ Enable ClamAV Virus Scanner
 1. Install ClamAV
 2. Edit the ClamAV configuration file to include the following properties:
 
-.. code-block:: guess
+.. code-block:: aconf
   :caption: clamd.conf
   :linenos:
 

--- a/source/system-administrators/studio/studio-configuration-overrides.rst
+++ b/source/system-administrators/studio/studio-configuration-overrides.rst
@@ -84,7 +84,7 @@ Database Configuration
 
 The following section of Studio's configuration overrides allows you to setup the database url, port number, connection string to initialize the database and path
 
-.. code-block:: guess
+.. code-block:: yaml
    :caption: shared/classes/crafter/studio/extension/studio-config-override.yaml
    :linenos:
 

--- a/source/system-administrators/upgrade/upgrading-to-craftercms-3-0.rst
+++ b/source/system-administrators/upgrade/upgrading-to-craftercms-3-0.rst
@@ -180,7 +180,7 @@ The import script will basically attempt to execute these operations:
 After this, you just need to wait for the site creation process to complete. You can tail the ``crafter-authoring/logs/tomcat/catalina.out`` meanwhile to
 watch the progress. The site should be ready when you see the following line in the log:
 
-.. code-block:: guess
+.. code-block:: text
 
   [INFO] 2018-03-29 11:54:42,063 [studioSchedulerFactoryBean_Worker-1] [site.SiteServiceImpl] | Done syncing database with repository for site: mysite fromCommitId = a1f2f8beba50da9cc75fcd3aa97d412750ef5225 with a final result of: true
   [INFO] 2018-03-29 11:54:42,063 [studioSchedulerFactoryBean_Worker-1] [site.SiteServiceImpl] | Last commit ID for site: mysite is 069f82a4bb3bce1e8cb3c2abc030f9a2cb68e9a9


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
Update code-block guess lexers for updated sphinx-doc version.

After updating sphinx-doc (v2.3.1), there were updates to the lexer where `guess` is not supported anymore.  

The option `:force:` was also added, to ignore minor errors on highlighting, for code-blocks listing ftls for example (no lexer for ftl, but can use `html` to have highlights on html part), or using ellipses inside code-block  to represent repetitive values, etc.

https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html

Please note too that there will be a warning when building:
```
RemovedInSphinx30Warning: To modify script_files in the theme is deprecated. Please insert a <script> tag directly in your theme instead.
```
Ticket https://github.com/craftercms/craftercms/issues/3786 filed for above warning
