### PR TITLE
Fix warning of duplicate label

### DIFF
--- a/source/developers/projects/engine/api/site/context/status.rst
+++ b/source/developers/projects/engine/api/site/context/status.rst
@@ -1,6 +1,6 @@
 :is-up-to-date: True
 
-.. _crafter-engine-api-site-context-id:
+.. _crafter-engine-api-site-context-status:
 
 ==========
 Get Status


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
Fix warning of duplicate label for `crafter-engine-api-site-context-id`