### PR TITLE
Update CLUSTER_NAME variable in arbiter to match cluster example

### DIFF
--- a/source/system-administrators/activities/autoclustering-with-studio.rst
+++ b/source/system-administrators/activities/autoclustering-with-studio.rst
@@ -318,7 +318,7 @@ To setup the Studio Arbiter:
       :caption: Example configuration for the Studio Arbiter
 
       # Studio Arbiter configuration
-      export CLUSTER_NAME=studiodb_cluster
+      export CLUSTER_NAME=studio_db_cluster
       export CLUSTER_ADDRESS=192.168.1.100,192.168.1.101
       
    |


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
The Auto-Clustering example uses `CLUSTER_NAME=studio_db_cluster` update the value in the Studio Arbiter example to match. 