### PR TITLE
Clarify remote assets controller is a Crafter Delivery feature

### DIFF
--- a/source/developers/remote-assets.rst
+++ b/source/developers/remote-assets.rst
@@ -8,11 +8,11 @@
 Remote Assets
 -------------
 
-Remote assets are binary files, typically images, videos, pdf documents, etc. which are hosted outside of Crafter Studio.  Remote assets could be hosted in AWS, Box or some other server accessed through WebDAV, CMIS. etc.
+Remote assets are binary files, typically images, videos, pdf documents, etc. which are hosted outside of Crafter Studio and Crafter Delivery.  Remote assets could be hosted in AWS, Box or some other server accessed through WebDAV, CMIS. etc.
 
-Various data sources are available to help manage/use assets hosted outside of Crafter Studio in your site.  The ``Developer`` section contains some examples on how to store assets remotely, such as :ref:`use-s3-to-store-assets` and :ref:`use-box-to-store-assets`.  The ``Site Administrators`` section contains information on how to configure Crafter Studio to access services used for storing assets remotely here: :ref:`studio-configuration`.
+For authoring, various Crafter Studio data sources are available to help manage/select assets hosted outside of your site.  The ``Developer`` section contains some examples on how to store assets remotely, such as :ref:`use-s3-to-store-assets` and :ref:`use-box-to-store-assets`.  The ``Site Administrators`` section contains information on how to configure Crafter Studio to access services used for storing assets remotely here: :ref:`studio-configuration`.
 
-Crafter Studio by default has the remote assets controller open up the remote repository for read access via the URL pattern ``/remote-assets/STORE-TYPE/PROFILE-ID/PATH-TO-ASSET``, where:
+Browser access to remote assets on your site is provided by Crafter Delivery remote assets controller via the URL pattern ``/remote-assets/STORE-TYPE/PROFILE-ID/PATH-TO-ASSET``, where:
 
    * **STORE-TYPE** the remote repository storage used, for our example above, **S3**
    * **PROFILE-ID** ID used to refer to remote repository profile

--- a/source/developers/remote-assets.rst
+++ b/source/developers/remote-assets.rst
@@ -8,11 +8,11 @@
 Remote Assets
 -------------
 
-Remote assets are binary files, typically images, videos, pdf documents, etc. which are hosted outside of Crafter Studio and Crafter Delivery.  Remote assets could be hosted in AWS, Box or some other server accessed through WebDAV, CMIS. etc.
+Remote assets are binary files, typically images, videos, pdf documents, etc. which are hosted outside of Crafter CMS.  Remote assets could be hosted in AWS S3 or compatible storage, Box or some other server accessed through WebDAV, CMIS. etc.
 
-For authoring, various Crafter Studio data sources are available to help manage/select assets hosted outside of your site.  The ``Developer`` section contains some examples on how to store assets remotely, such as :ref:`use-s3-to-store-assets` and :ref:`use-box-to-store-assets`.  The ``Site Administrators`` section contains information on how to configure Crafter Studio to access services used for storing assets remotely here: :ref:`studio-configuration`.
+Various data sources are available to help manage/select assets hosted outside of Crafter CMS.  The ``Developer`` section contains some examples on how to store assets remotely, such as :ref:`use-s3-to-store-assets` and :ref:`use-box-to-store-assets`.  The ``Site Administrators`` section contains information on how to configure Crafter CMS to access services used for storing assets remotely here: :ref:`studio-configuration`.
 
-Browser access to remote assets on your site is provided by Crafter Delivery remote assets controller via the URL pattern ``/remote-assets/STORE-TYPE/PROFILE-ID/PATH-TO-ASSET``, where:
+Browser access to remote assets on your site is provided by Crafter Engine's remote assets controller via the URL pattern ``/remote-assets/STORE-TYPE/PROFILE-ID/PATH-TO-ASSET``, where:
 
    * **STORE-TYPE** the remote repository storage used, for our example above, **S3**
    * **PROFILE-ID** ID used to refer to remote repository profile


### PR DESCRIPTION
The ability to reference remote assets is a feature provided by Crafter Delivery (not Studio). Remote asset data source is a Crafter Studio feature that helps create the URL patterns mentioned here. It is the remote assets controller of Crafter Delivery that parses that URL pattern and provides the access to browsers.

### Ticket reference or full description of what's in the PR
