### PR TITLE
Update get-go-live-items.rst

### DIFF
--- a/source/developers/projects/studio/api/workflow/get-go-live-items.rst
+++ b/source/developers/projects/studio/api/workflow/get-go-live-items.rst
@@ -6,7 +6,7 @@
 Get Go Live Items
 =================
 
-Get items waiting for approval.
+Get items waiting for approval. Optionally, include in-progress items. Note, there can be a significant performance cost to including in-progress items.
 
 --------------------
 Resource Information


### PR DESCRIPTION
Add note about performance costs of flipping the in-progress items flag (more than 10x on editorial sample site alone).

### Ticket reference or full description of what's in the PR
