### PR TITLE
Controller should add new objects to templateModel

### DIFF
--- a/source/developers/content-modeling.rst
+++ b/source/developers/content-modeling.rst
@@ -925,7 +925,7 @@ script in Scripts > components > upcoming-events.groovy so that it is executed f
       }
     }
 
-    contentModel.events = events
+    templateModel.events = events
 
 |
 


### PR DESCRIPTION
In Groovy context, contentModel is a SiteItem. Statement "contentModel.events = events" will cause this exception:

    groovy.lang.MissingPropertyException: No such property: events for class: org.craftercms.engine.model.DefaultSiteItem

### Ticket reference or full description of what's in the PR
