### PR TITLE
Groovy package name must match path under /scripts/classes

### DIFF
--- a/source/developers/projects/engine/api/groovy-api.rst
+++ b/source/developers/projects/engine/api/groovy-api.rst
@@ -238,7 +238,7 @@ script in Scripts > components > upcoming-events.groovy so that it is executed f
     contentModel.events = events
 
 You might notice that we're importing a ``utils.DateUtils`` class. This class is not part of Crafter CMS, but instead it is a Groovy class
-specific to the site. To be able to use this class, you should place it under Classes > groovy > utils and name it DateUtils.groovy,
+specific to the site. To be able to use this class, you should place it under Scripts > classes > utils and name it DateUtils.groovy,
 where everything after the groovy directory is part of the class' package. It's recommended for all Groovy classes to follow this
 convention.
 ::


### PR DESCRIPTION
The "/groovy/" folder might have been from older version.

### Ticket reference or full description of what's in the PR
