### PR TITLE
[3.1] Fix typo in sitemap.groovy example

### DIFF
--- a/source/developers/projects/engine/api/groovy-api.rst
+++ b/source/developers/projects/engine/api/groovy-api.rst
@@ -174,7 +174,7 @@ controller then must be placed in Scripts > controllers > sitemap.groovy. The co
         }
     }
 
-    response.flush()
+    response.flushBuffer()
 
     return null
 


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
Fix typo in sitemap.groovy example