### PR TITLE
Fix typo in version numbers for docker config changes from 3.1.12 to 3.1.13

### DIFF
--- a/source/system-administrators/upgrade/docker/config/config-changes-3.1.12-to-3.1.13.rst
+++ b/source/system-administrators/upgrade/docker/config/config-changes-3.1.12-to-3.1.13.rst
@@ -3,15 +3,15 @@
 .. _docker-config-changes-3-1-12-to-3-1-13:
 
 ===========================================================================
-Configuration changes between Crafter CMS version 3.1.11 and version 3.1.12 
+Configuration changes between Crafter CMS version 3.1.12 and version 3.1.13
 ===========================================================================
 
-The following is the list of configuration files that have changed from 3.1.11 to 3.1.12 (all are relative to the Crafter 
+The following is the list of configuration files that have changed from 3.1.12 to 3.1.13 (all are relative to the Crafter
 installation path ``/opt/crafter`` inside the Docker images):
 
    - For the ``authoring_tomcat`` and ``authoring_tomcat_solr_compatible`` images:
 
       - ``bin/crafter-setenv.sh``:
       
-         - 3.1.11: https://github.com/craftercms/craftercms/blob/v3.1.11/resources/env/authoring/bin/crafter-setenv.sh
          - 3.1.12: https://github.com/craftercms/craftercms/blob/v3.1.12/resources/env/authoring/bin/crafter-setenv.sh
+         - 3.1.13: https://github.com/craftercms/craftercms/blob/v3.1.13/resources/env/authoring/bin/crafter-setenv.sh


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
Fix typo in version numbers for docker config changes from 3.1.12 to 3.1.13