### PR TITLE
Fix warning for spacing in crafter search api

### DIFF
--- a/source/developers/projects/search/api/index.rst
+++ b/source/developers/projects/search/api/index.rst
@@ -4,9 +4,9 @@
 
 .. _crafter-search-api:
 
-====================
+==================
 Crafter Search API
-====================
+==================
 
 The context for this API is ``/crafter-search/``, please prefix the API URLs with this context.
 
@@ -14,6 +14,7 @@ The context for this API is ``/crafter-search/``, please prefix the API URLs wit
 	The Index Management and Content Management APIs are secured using an access token that needs to be provided as a
 	query string parameter with name ``token``. The value of the token should be changed for every environment or set
 	to empty to allow anonymous access for any request. For more details see :ref:`securing-your-crafter-cms-install`
+
 |
 
 ----------------


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
Fix warning for spacing and over line in crafter search api