### PR TITLE
[3.1] Update sample commits api to use environment live instead of Live

### DIFF
--- a/source/developers/projects/studio/api/publish/commits.rst
+++ b/source/developers/projects/studio/api/publish/commits.rst
@@ -56,7 +56,7 @@ Request
 
     {
         "site_id" : "mysite",
-        "environment": "Live"
+        "environment": "live"
         "commit_ids" :
             [
                 "c89ee1cb2be4b41b0966d20c12d53b68ca70d74a",


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
Due to the update from 3.1.6 to 3.1.7: https://docs.craftercms.org/en/3.1/release-notes/index.html?#crafter-cms-3-1-7

> The environment-config.xml configuration has been removed
> The following tags from the environment-config.xml file has been removed and staging and live are now used as defaults for the repository branch name for publishing targets:
> 
> The tags below from “environment-config.xml” no longer exist, “staging” and “live” are now used as default publishing targets¶

```
<open-sidebar />
<publishing-targets>
  <target>
    <repo-branch-name />
    <display-label />
  </target>
</publishing-targets>
```

The API call with "Live" is no longer work as we don't have `<display-label>Live</display-label>` anymore. For that reason, using `live` in the sample to make it consistent. 