### PR TITLE
Add note to enable http basic auth flag

### DIFF
--- a/source/developers/cook-books/how-tos/working-with-crafter-studios-api.rst
+++ b/source/developers/cook-books/how-tos/working-with-crafter-studios-api.rst
@@ -24,7 +24,7 @@ Let's begin:
 
    There are two authentication methods that can be used: JWT and HTTP Basic
 
-.. _access-tokens:
+   .. _access-tokens:
 
    **JWT Authentication**
 
@@ -109,7 +109,8 @@ Let's begin:
       ``curl -H 'Authentication: Bearer <access token>' ...``
 
    |
-   |
+
+   .. _http-basic-authentication:
 
    **HTTP Basic Authentication**
 

--- a/source/system-administrators/devcontentops-toolkit/add-environment.rst
+++ b/source/system-administrators/devcontentops-toolkit/add-environment.rst
@@ -44,20 +44,22 @@ Example
 
 Here's an example of issuing the ``add-environment`` command to setup the connection to CrafterCMS.  We'll use ``local`` for the name, ``http://localhost:8080`` for the url, and a token for the authentication.  (See :ref:`here <access-tokens>` for the steps on how to create a token.)  Leave the token blank, you will be prompted for the token after issuing the ``add-environment`` command:
 
-   .. code-block:: bash
+.. code-block:: bash
 
-      ➜  ./crafter-cli add-environment -e local -u http://localhost:8080 --token
-      Enter value for --token (The access token for authentication):
-      Environment added
+   ➜  ./crafter-cli add-environment -e local -u http://localhost:8080 --token
+   Enter value for --token (The access token for authentication):
+   Environment added
 
-   |
+|
 
-If you're using HTTP basic for authentication when issuing the ``add-environment`` command, use ``username`` and ``password`` for the authentication.  We'll use ``local`` for the name, ``http://localhost:8080`` for the url, and ``john`` for the username.  Leave the password blank, you will be prompted for the password after issuing the ``add-environment`` command:
+If you're using HTTP basic for authentication when issuing the ``add-environment`` command, use ``username`` and ``password`` for the authentication.  Remember to enable the flag for HTTP basic auth to enable using the ``username`` and ``password`` for authentication as described :ref:`here <http-basic-authentication>`.
 
-   .. code-block:: bash
+We'll use ``local`` for the name, ``http://localhost:8080`` for the url, and ``john`` for the username.  Leave the password blank, you will be prompted for the password after issuing the ``add-environment`` command:
 
-       ➜  ./crafter-cli add-environment -e local -u http://localhost:8080 --username john --password
-       Enter value for --password (The password for authentication):
-       Environment added
+.. code-block:: bash
 
-   |
+    ➜  ./crafter-cli add-environment -e local -u http://localhost:8080 --username john --password
+    Enter value for --password (The password for authentication):
+    Environment added
+
+|

--- a/source/system-administrators/devcontentops-toolkit/index.rst
+++ b/source/system-administrators/devcontentops-toolkit/index.rst
@@ -15,7 +15,7 @@ To run the command line tool (CrafterCMS Command line Interface (CLI) for DevCon
 * **crafter-cli:** - for users on a Linux/macOS operating system
 * **crafter-cli.bat** - for users on a Windows operating system
 
-When using the **crafter-cli**, we first need to setup the connection to CrafterCMS before we can use the other available commands.  To setup the connection, run the ``add-environment`` command,  provide a name, the url for a CrafterCMS authoring server and the authentication information.
+When using the **crafter-cli**, we first need to setup the connection to CrafterCMS before we can use the other available commands.  To setup the connection, run the :ref:`add-environment <crafter-cli-add-environment>` command,  provide a name, the url for a CrafterCMS authoring server and the authentication information.
 
 For the example below, we'll use ``local`` for the name, ``http://localhost:8080`` for the url, and your access token for the authentication.  See :ref:`here <access-tokens>` for the steps on how to create a token.  Leave the token blank, you will be prompted for the token after issuing the ``add-environment`` command:
 


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
Add note to enable http basic auth flag when using username/password for authentication in the `add-environment` command of `crafter-cli`