### PR TITLE
Remove build and searchEngine in descriptor #5224

### DIFF
--- a/source/developers/plugins/blueprints.rst
+++ b/source/developers/plugins/blueprints.rst
@@ -279,7 +279,6 @@ To store files in an S3 bucket, we'll follow :ref:`this <use-s3-to-store-assets>
         id: org.craftercms.blueprint.editorial
         name: Website Editorial Blueprint
       ...
-      searchEngine: Elasticsearch
       parameters:
         - label: Access Key
           name: accessKey

--- a/source/developers/plugins/plugin-descriptor.rst
+++ b/source/developers/plugins/plugin-descriptor.rst
@@ -53,9 +53,6 @@ Here's a sample taken from the  ``craftercms-plugin.yaml`` for the Empty bluepri
           name: CrafterCMS
           email: info@craftercms.com
           url: https://craftercms.com/
-      build:
-        id: c3d2a5444e6a24b5e0481d6ba87901d0b02716c8
-        date: 2021-01-23T00:00:00Z
       license:
         name: MIT
         url: https://opensource.org/licenses/MIT
@@ -66,7 +63,6 @@ Here's a sample taken from the  ``craftercms-plugin.yaml`` for the Empty bluepri
       crafterCmsEditions:
         - community
         - enterprise
-      searchEngine: Elasticsearch
 
 where the following fields are required:
 
@@ -78,7 +74,6 @@ where the following fields are required:
 - ``plugin.version`` - a version number for the blueprint/site plugin
 - ``plugin.crafterCmsVersions`` - CrafterCMS versions that the plugin is compatible with (look in the :ref:`release-notes`
   section for the versions available), and you'll need to keep this up to date
-- ``plugin.searchEngine`` - search engine your plugin requires, the only value possible at this time is``Elasticsearch``
 
 |
 |
@@ -188,9 +183,6 @@ Below is a sample ``craftercms-plugin.yaml`` for a form control plugin descripto
          name: CrafterCMS
          email: info@craftercms.com
          url: https://craftercms.com
-     build:
-       id: f9d09cbf39167609bcca4e31f5d2475d0ef14f8a
-       date: 2021-05-21T00:00:00Z
      license:
        name: MIT
        url: https://opensource.org/licenses/MIT

--- a/source/developers/plugins/site-plugins.rst
+++ b/source/developers/plugins/site-plugins.rst
@@ -149,10 +149,9 @@ Here's an example directory structure for a site plugin:
 
 where:
 
-- **yourPluginFilesAndFolders** : Freemarker, Groovy and binary files/folders containing the plugin implementation
 - **yourPluginType** : Type of plugin, e.g. control, datasource, sidebar, app, etc.
 - **yourPluginName** : Name of  plugin
-- **yourPluginFilesAndFolders** : JavaScript and/or plugin build output files/folders containing the plugin implementation
+- **yourPluginFilesAndFolders** : JavaScript, Freemarker, Groovy, binary and/or plugin build output files/folders containing the plugin implementation
 
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
Remove build and searchEngine in plugin descriptor docs https://github.com/craftercms/craftercms/issues/5224
Fix description for `YourPluginFilesAndFolder`
