### PR TITLE
Marking API v1 'go-delete' as deprecated

### DIFF
--- a/source/developers/projects/studio/api/workflow/go-delete.rst
+++ b/source/developers/projects/studio/api/workflow/go-delete.rst
@@ -2,11 +2,14 @@
 
 .. _crafter-studio-api-workflow-go-delete:
 
-=========
-Go Delete
-=========
+======================
+Go Delete (deprecated)
+======================
 
 Go delete workflow.
+
+.. important::
+   This API is deprecated and provided only as a reference.  Please see :studio_swagger_url:`#/content/contentDelete` for the current version.
 
 --------------------
 Resource Information


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/5640