### PR TITLE
Fix GraphQL GET Query Example

### DIFF
--- a/source/developers/projects/engine/api/site/graphql/get.rst
+++ b/source/developers/projects/engine/api/site/graphql/get.rst
@@ -48,7 +48,7 @@ Example
 Request
 ^^^^^^^
 
-``GET .../api/1/site/graphql.json?query={page_article{items{title}}}``
+``GET .../api/1/site/graphql.json?query={page_article{items{title_t}}}``
 
 ^^^^^^^^
 Response


### PR DESCRIPTION
Changed `GET .../api/1/site/graphql.json?query={page_article{items{title}}}` for `GET .../api/1/site/graphql.json?query={page_article{items{title_t}}}` since the GraphQL GET query example was failing with an error:

```
{
    "errors": [
        {
            "message": "Validation error of type FieldUndefined: Field 'title' in type 'page_article' is undefined @ 'page_article/items/title'",
            "locations": [
                {
                    "line": 1,
                    "column": 21
                }
            ],
            "extensions": {
                "classification": "ValidationError"
            }
        }
    ]
}
```