### PR TITLE
[3.1] Fix broken link and update link to be anonymous

### DIFF
--- a/source/developers/plugins/studio-plugins.rst
+++ b/source/developers/plugins/studio-plugins.rst
@@ -13,7 +13,7 @@ Studio plugins extend the authoring environment and can be pieces within Studio 
 
 Stand alone plugins can make use of Studio UI components using various possible mechanisms described below.
 
-The Crafter Studio API that gets a file for a given plugin, the ``getPluginFile`` API found here `getPluginFile <../../_static/api/studio.html#tag/plugin/operation/getPluginFile>`_ facilitates extending Studio through plugins.
+The Crafter Studio API that gets a file for a given plugin, the ``getPluginFile`` API found here `getPluginFile <../../_static/api/studio.html#tag/plugin/operation/getPluginFile>`__ facilitates extending Studio through plugins.
 
 --------------------------
 Plugin Directory Structure
@@ -125,7 +125,7 @@ You can use ``JSX``, ``TypeScript`` or any form of transpiling when developing y
 Your plugin's build script would then transpile your app and write the output on the plugin folder and commit that
 output so Studio can see it. If your plugin size allows, it is preferable to have a single bundled file. If you do
 need multiple files (e.g. more JS files, CSS files, other), you may have them; simply bear in mind that loading them
-into the page would need to be done through the ``getPluginFile`` API found here `getPluginFile <../../_static/api/studio.html#tag/plugin/operation/getPluginFile>`_ (i.e. it's not a regular web resource loaded
+into the page would need to be done through the ``getPluginFile`` API found here `getPluginFile <../../_static/api/studio.html#tag/plugin/operation/getPluginFile>`__ (i.e. it's not a regular web resource loaded
 via it's physical path).
 
 To load a file, the URL would look like:

--- a/source/developers/plugins/studio/form-control-plugins.rst
+++ b/source/developers/plugins/studio/form-control-plugins.rst
@@ -8,7 +8,7 @@
 Building Form Engine Control Plugins
 ====================================
 
-In :ref:`form-engine-control`, we learned how to build form engine controls placed in the Studio war file.  Crafter Studio also allows plugins for form engine controls through the ``getPluginFile`` API found here `getPluginFile <../../../_static/api/studio.html#tag/plugin/operation/getPluginFile>`_
+In :ref:`form-engine-control`, we learned how to build form engine controls placed in the Studio war file.  Crafter Studio also allows plugins for form engine controls through the ``getPluginFile`` API found here `getPluginFile <../../../_static/api/studio.html#tag/plugin/operation/getPluginFile>`__
 
 -------------------------------
 The anatomy of a Control Plugin

--- a/source/developers/plugins/studio/form-data-source-plugins.rst
+++ b/source/developers/plugins/studio/form-data-source-plugins.rst
@@ -8,7 +8,7 @@
 Building Form Engine Data Source Plugins
 ========================================
 
-In :ref:`form-engine-data-source`, we learned how to build form engine data sources placed in the Studio war file.  Crafter Studio also allows plugins for form engine data sources through the ``getPluginFile`` API found here `getPluginFile <../../_static/api/studio.html#tag/plugin/operation/getPluginFile>`_
+In :ref:`form-engine-data-source`, we learned how to build form engine data sources placed in the Studio war file.  Crafter Studio also allows plugins for form engine data sources through the ``getPluginFile`` API found here `getPluginFile <../../../_static/api/studio.html#tag/plugin/operation/getPluginFile>`__
 
 -----------------------------------
 The anatomy of a Data Source Plugin


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
Fix broken link and update links to be anonymous (by using two trailing underscores)

According to: http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#anonymous-hyperlinks
```
With a single trailing underscore, the reference is named and the same target URI may be referred to again. With two trailing underscores, the reference and target are both anonymous, and the target cannot be referred to again. These are "one-off" hyperlinks.
```