### PR TITLE
Explain usage of x-crafter-site header

### DIFF
--- a/source/by-role/system-admin/configuration.rst
+++ b/source/by-role/system-admin/configuration.rst
@@ -321,6 +321,8 @@ Depending on your setup, the following CrafterCMS properties may need to be setu
 - ``crafter.engine.forwarded.headers.enabled`` property under :ref:`engine-forwarded-headers` in the ``server-config.properties`` file
 - ``studio-config-forwarded-headers`` property under :ref:`studio-forwarded-headers` in the ``studio-config-override.yaml`` file
 
+Note, that when configuring the delivery environment, it is possible to specify a header called ``X-Crafter-Site`` set to the value of ``{myproject}`` instead of using a URL rewrite as shown in the examples above.
+
 |hr|
 
 ------

--- a/source/reference/modules/engine/configuration.rst
+++ b/source/reference/modules/engine/configuration.rst
@@ -107,7 +107,13 @@ Viewing your Site for Testing
 """""""""""""""""""""""""""""
 To test viewing your project, open a browser and type in the URL of your project.
 
-If you have multiple projects setup, to view a certain project, in your browser, enter the following:
+If you have multiple projects setup, to view a certain project, you have two choices.  First, you can set a request header to specify the project name:
+
+.. code-block:: sh
+
+    X-Crafter-Site: {siteName}
+
+or, alternately, you can set a query parameter onto the URL, as follows:
 
 .. code-block:: sh
 


### PR DESCRIPTION
Added mention of the x-crafter-site header to the two most relevant locations in the installation docs.