### PR TITLE
[4.0] Add escaping html and scripts section in templating API #795

### DIFF
--- a/source/developers/projects/engine/api/templating-api.rst
+++ b/source/developers/projects/engine/api/templating-api.rst
@@ -209,6 +209,18 @@ Crafter Engine allows executing scripts/controllers from inside Freemarker templ
    <@controller path=“/scripts/plugins/MyPlugin/1/get-tweets.groovy” />
    <@controller path=“/scripts/plugins/MyPlugin/1/get-fbs.groovy” />
 
+-------------------------
+Escaping HTML and Scripts
+-------------------------
+To escape HTML and scripts and prevent their execution in your template, simply wrap the HTML/script to be
+escaped with the ``outputformat`` Freemarker directive set to ``html``:
+
+.. code-block::
+    :caption: *Escaping HTML and Scripts in Templates*
+
+    <#outputformat "HTML">
+    ...
+    </#outputformat>
 
 ------------------------
 Keeping Templates Simple


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
Add escaping html and scripts section in templating API  https://github.com/craftersoftware/craftercms/issues/795