### PR TITLE
Trivial YAML spacing change

### DIFF
--- a/source/reference/modules/studio/configuration/index.rst
+++ b/source/reference/modules/studio/configuration/index.rst
@@ -682,7 +682,7 @@ Add the following lines with the regex for the item you wish not to be published
 
     # Publishing blacklist configuration, items matching regexes on this list will never be published
     studio.configuration.publishing.blacklist.regex: >-
-    .*/\.keep
+        .*/\.keep
 
 |
 
@@ -706,7 +706,7 @@ Say, you do not want files under ``/static-assets/images/mytempimages`` to be pu
 
     # Publishing blacklist configuration, items matching regexes on this list will never be published
     studio.configuration.publishing.blacklist.regex: >-
-    .*/\.keep,\/static-assets\/images\/mytempimages\/.*
+        .*/\.keep,\/static-assets\/images\/mytempimages\/.*
 
 |
 


### PR DESCRIPTION
The >- notation is not commonly used but the following line requires an indent for the syntax to be correct.

### Ticket reference or full description of what's in the PR
