### PR TITLE
Fix typo in role name and malformed permissions tag in example

### DIFF
--- a/source/site-administrators/studio/permission-mappings.rst
+++ b/source/site-administrators/studio/permission-mappings.rst
@@ -121,7 +121,7 @@ Sample
       For example, to grant the role component_author the ability to read/write
       components and read-only to everything else:
 
-          <role name="author">
+          <role name="component_author">
               <rule regex="/site/website/.*">
                 <allowed-permissions>
                   <permission>Read</permission>
@@ -158,7 +158,7 @@ Sample
           </rule>
 
     -->
-    permissions>
+    <permissions>
       <version>12</version>
       <role name="author">
         <rule regex="/site/website/.*">


### PR DESCRIPTION
While reading the 3.1 documentation, I noticed two small issues in the permission-mappings example:

1. The example says it grants permissions to the `component_author` role, but the XML uses `<role name="author">`. I changed it to `<role name="component_author">` to match the description above.

2. In the full sample XML block further down, the `<permissions>` tag was missing its opening `<`, making the example invalid XML. I fixed that as well.

These are minor corrections, but they may help avoid confusion when users copy-paste the examples.

I also looked into the repository's CONTRIBUTING.md file and reviewed existing commits to check for any commit message conventions. Since there doesn't appear to be a strict format enforced, I followed the general style used in previous commits.

Let me know if anything should be adjusted. :)
